### PR TITLE
fix: show scrollbar in Git settings

### DIFF
--- a/crates/editor/ui_git_manager/src/components/git_settings.rs
+++ b/crates/editor/ui_git_manager/src/components/git_settings.rs
@@ -1,15 +1,15 @@
 use crate::git_hooks::GitHooksConfig;
 use gpui::{
-    AppContext as _, Context, Div, Entity, IntoElement, ParentElement as _, Render,
-    StatefulInteractiveElement as _, Styled as _, Subscription, Window, div,
-    prelude::FluentBuilder as _, px,
+    AppContext as _, Context, Div, Entity, IntoElement, ParentElement as _, Render, Styled as _,
+    Subscription, Window, div, prelude::FluentBuilder as _, px,
 };
 use ui::{
-    ActiveTheme as _, Disableable as _, IconName,
+    ActiveTheme as _, Disableable as _, IconName, StyledExt as _,
     alert::Alert,
     button::{Button, ButtonVariants as _},
     h_flex,
     input::{InputState, NumberInput, NumberInputEvent, TextInput},
+    scroll::ScrollbarAxis,
     switch::Switch,
     v_flex,
 };
@@ -141,7 +141,7 @@ impl Render for GitSettingsForm {
         v_flex()
             .w_full()
             .max_h(content_max_height)
-            .overflow_y_scroll()
+            .scrollable(ScrollbarAxis::Vertical)
             .pr_2()
             .gap_6()
             .child(


### PR DESCRIPTION
## Summary

- replace the Git settings form's bare vertical overflow behavior with the shared UI library's canonical vertical scrollbar wrapper
- preserve the existing viewport-derived maximum height while making the scroll affordance visible
- remove the now-unused GPUI interaction-trait import

Closes #498.

## Testing

- `rustfmt --edition 2024 --check crates/editor/ui_git_manager/src/components/git_settings.rs`
- `cargo check -p ui_git_manager`
- `cargo test -p ui_git_manager` — 55 passed; doc tests 0/0
- `cargo clippy -p ui_git_manager --all-targets --no-deps`
- `git diff --check`

## Baseline limitations

- Adding `-- -D warnings` to the package clippy command exposes 25 pre-existing warnings in untouched files; the edited file is absent from that failure list.
- Workspace-wide `cargo fmt --all --check` is blocked by broad existing formatting drift and a missing file in the pinned WGPUI submodule. The edited file passes direct Rustfmt.

Tooling disclosure: this change was prepared with OpenAI Codex and validated with the commands above.
