### PR TITLE
Fix double-wrapped searchable dropdowns

### DIFF
--- a/crates/editor/ui_common/src/locale_picker.rs
+++ b/crates/editor/ui_common/src/locale_picker.rs
@@ -85,10 +85,6 @@ impl Render for LocalePicker {
         v_flex()
             .w(px(280.))
             .bg(bg)
-            .rounded_xl()
-            .shadow_xl()
-            .border_1()
-            .border_color(border)
             .overflow_hidden()
             .track_focus(&self.focus_handle)
             .child(

--- a/crates/editor/ui_common/src/menu/dev_popover.rs
+++ b/crates/editor/ui_common/src/menu/dev_popover.rs
@@ -384,10 +384,6 @@ impl Render for DevPopover {
             .max_h(px(640.))
             .overflow_y_scroll()
             .bg(bg)
-            .rounded_xl()
-            .shadow_xl()
-            .border_1()
-            .border_color(border)
             .overflow_hidden()
             .track_focus(&self.focus_handle)
             // ── Header ───────────────────────────────────────────────────────

--- a/crates/editor/ui_common/src/theme_dropdown.rs
+++ b/crates/editor/ui_common/src/theme_dropdown.rs
@@ -139,10 +139,6 @@ impl Render for ThemePicker {
         v_flex()
             .w(px(300.))
             .bg(bg)
-            .rounded_xl()
-            .shadow_xl()
-            .border_1()
-            .border_color(border)
             .overflow_hidden()
             .track_focus(&self.focus_handle)
             // ── Search header ────────────────────────────────────────────────

--- a/crates/editor/ui_file_manager/src/components/commit_picker.rs
+++ b/crates/editor/ui_file_manager/src/components/commit_picker.rs
@@ -81,10 +81,6 @@ impl Render for CommitPicker {
         v_flex()
             .w(px(360.))
             .bg(bg)
-            .rounded_xl()
-            .shadow_xl()
-            .border_1()
-            .border_color(border)
             .overflow_hidden()
             .track_focus(&self.focus_handle)
             .child(


### PR DESCRIPTION
## Summary
- let the shared `Popover` provide the outer chrome for searchable theme and locale pickers
- remove duplicate picker borders, rounding, and shadows
- preserve the search header, scrolling, and click-outside dismissal behavior

Fixes #534

## Validation
- `cargo check -p ui_common`
- `cargo test -p ui_common --lib` (2 passed)
- `git diff --check`