### PR TITLE
Phase B2: ComponentRuntimeBehavior::sync_component becomes typed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1674,7 +1674,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2633,7 +2633,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3036,6 +3036,8 @@ dependencies = [
  "pulsar_reflection",
  "pulsar_scenedb 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/SceneDB?branch=engine-class-scenestore-export)",
  "quote",
+ "serde",
+ "serde_json",
  "syn 2.0.119",
  "tracing",
  "wgpu",
@@ -3250,7 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5391,7 +5393,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5762,7 +5764,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7010,7 +7012,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8702,7 +8704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -8721,7 +8723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9069,7 +9071,7 @@ version = "0.1.0"
 [[package]]
 name = "pulsar_reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=4cc82f5eff1ce2b515c7045eafee88f451dd14bb#4cc82f5eff1ce2b515c7045eafee88f451dd14bb"
+source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=ece8e759c33ee7cc42127372117de8bec1636463#ece8e759c33ee7cc42127372117de8bec1636463"
 dependencies = [
  "dashmap",
  "glam 0.33.2",
@@ -9087,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "pulsar_reflection_derive"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=4cc82f5eff1ce2b515c7045eafee88f451dd14bb#4cc82f5eff1ce2b515c7045eafee88f451dd14bb"
+source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=ece8e759c33ee7cc42127372117de8bec1636463#ece8e759c33ee7cc42127372117de8bec1636463"
 dependencies = [
  "owo-colors",
  "proc-macro2",
@@ -9297,7 +9299,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -9337,9 +9339,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10259,7 +10261,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10326,7 +10328,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10940,7 +10942,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -11185,7 +11187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11522,7 +11524,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11957,10 +11959,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11999,7 +12001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13132,7 +13134,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14606,7 +14608,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15114,7 +15116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9071,7 +9071,7 @@ version = "0.1.0"
 [[package]]
 name = "pulsar_reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=ece8e759c33ee7cc42127372117de8bec1636463#ece8e759c33ee7cc42127372117de8bec1636463"
+source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=4b489372bfb81607631c4ec8c7d7289efe709f40#4b489372bfb81607631c4ec8c7d7289efe709f40"
 dependencies = [
  "dashmap",
  "glam 0.33.2",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "pulsar_reflection_derive"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=ece8e759c33ee7cc42127372117de8bec1636463#ece8e759c33ee7cc42127372117de8bec1636463"
+source = "git+https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=4b489372bfb81607631c4ec8c7d7289efe709f40#4b489372bfb81607631c4ec8c7d7289efe709f40"
 dependencies = [
  "owo-colors",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ pulsar_game                        = { path = "crates/core/pulsar_game" }
 pulsar_core                        = { path = "crates/core/pulsar_core" }
 pulsar_pie_abi                     = { path = "crates/core/pulsar_pie_abi" }
 pulsar_scenedb                     = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "43921b0d432e99654161e1de65799fb65fa629f0" }
-pulsar_reflection                  = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
+pulsar_reflection                  = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "4b489372bfb81607631c4ec8c7d7289efe709f40" }
 pulsar_events                      = { path = "crates/core/pulsar_events" }
 engine_class_derive                = { path = "crates/core/engine_class_derive" }
 pulsar_scene                       = { path = "crates/subsystems/pulsar_scene" }
@@ -205,7 +205,7 @@ git2 = "0.21"
 walkdir = "2.4"
 rfd = "0.17"
 thiserror = "2.0"
-pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
+pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "4b489372bfb81607631c4ec8c7d7289efe709f40" }
 dashmap = "6.1.0"
 inventory = "0.3"
 flume = "0.12"
@@ -302,8 +302,8 @@ pulsar_bp_executor = { path = "crates/core/pulsar_bp_executor" }
 # Point at the same unified source as the Pulsar-Reflection patch below so every
 # `pulsar_reflection` reference (whichever repo/rev it came from) collapses to a
 # single copy. Uses the double-slash URL alias (see that patch for why).
-pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
-pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
+pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4b489372bfb81607631c4ec8c7d7289efe709f40" }
+pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4b489372bfb81607631c4ec8c7d7289efe709f40" }
 
 [patch."https://github.com/Far-Beyond-Pulsar/PBGC"]
 pbgc = { path = "crates/third-party/pbgc" }
@@ -346,17 +346,22 @@ wgsl_std = { path = "crates/third-party/psgc/crates/wgsl_std" }
 # PR #3 merged, additive-only per that PR) -- a strict descendant of both
 # 9b887f1 and b9dd888, so this collapsed cleanly again either direction.
 #
-# NOW (TEMPORARY): d32ba8d, the tip of Pulsar-Reflection's unmerged
-# `typed-sync-component` branch -- Phase B2 of the SceneDB/Helio/reflection
-# unification plan (`.claude/plans/eager-plotting-lecun.md`), which types
-# `ComponentRuntimeBehavior::sync_component(component: &Self, ...)` instead
-# of `&serde_json::Value`. This is a breaking trait-signature change (unlike
-# Phase A's purely-additive `scene_store`), so bumping this pin and migrating
-# every real `#[register_runtime_behavior]` impl's signature
-# (`pulsar_rendering`/`pulsar_physics`, ~8 components) happened together, in
-# lockstep, in the same change -- see that plan's B2 section for why they
-# can't land separately. Durable fix: once `typed-sync-component` merges to
-# Pulsar-Reflection's `main`, repoint this rev there.
+# NOW: 4b48937 (Pulsar-Reflection#4, `typed-sync-component`, merged to
+# `main`) -- Phase B2 of the SceneDB/Helio/reflection unification plan
+# (`.claude/plans/eager-plotting-lecun.md`; tracked at Pulsar-Native#561),
+# which types `ComponentRuntimeBehavior::sync_component(component: &Self,
+# ...)` instead of `&serde_json::Value`. This was a breaking trait-signature
+# change (unlike Phase A's purely-additive `scene_store`), so bumping this
+# pin and migrating every real `#[register_runtime_behavior]` impl's
+# signature (`pulsar_rendering`/`pulsar_physics`, ~8 components) had to
+# happen together, in lockstep, in one change (Pulsar-Native#551) -- see
+# that plan's B2 section for why they couldn't land separately. Was
+# temporarily pinned to the pre-merge branch tip (d32ba8d, then ece8e75) for
+# the same reason SceneDB's own local-path pins exist elsewhere in this
+# file -- now that Pulsar-Reflection#4 has merged, this points at the real
+# `main` commit instead. Remaining cleanup (dropping this `[patch]` block
+# entirely) is tracked at Pulsar-Native#560, gated on SceneDB's own
+# `pulsar_reflection` pin catching up too (SceneDB#45).
 #
 # The patch target URL and the replacement URL must be *different* source strings
 # or cargo rejects "points to the same source". The extra slash in
@@ -365,5 +370,5 @@ wgsl_std = { path = "crates/third-party/psgc/crates/wgsl_std" }
 # Durable fix: bump SceneDB's pulsar_reflection pin to match and cascade the rev,
 # then delete these patches.
 [patch."https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection"]
-pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
-pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
+pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4b489372bfb81607631c4ec8c7d7289efe709f40" }
+pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4b489372bfb81607631c4ec8c7d7289efe709f40" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ pulsar_game                        = { path = "crates/core/pulsar_game" }
 pulsar_core                        = { path = "crates/core/pulsar_core" }
 pulsar_pie_abi                     = { path = "crates/core/pulsar_pie_abi" }
 pulsar_scenedb                     = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "43921b0d432e99654161e1de65799fb65fa629f0" }
-pulsar_reflection                  = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "4cc82f5eff1ce2b515c7045eafee88f451dd14bb" }
+pulsar_reflection                  = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
 pulsar_events                      = { path = "crates/core/pulsar_events" }
 engine_class_derive                = { path = "crates/core/engine_class_derive" }
 pulsar_scene                       = { path = "crates/subsystems/pulsar_scene" }
@@ -205,7 +205,7 @@ git2 = "0.21"
 walkdir = "2.4"
 rfd = "0.17"
 thiserror = "2.0"
-pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "4cc82f5eff1ce2b515c7045eafee88f451dd14bb" }
+pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
 dashmap = "6.1.0"
 inventory = "0.3"
 flume = "0.12"
@@ -302,8 +302,8 @@ pulsar_bp_executor = { path = "crates/core/pulsar_bp_executor" }
 # Point at the same unified source as the Pulsar-Reflection patch below so every
 # `pulsar_reflection` reference (whichever repo/rev it came from) collapses to a
 # single copy. Uses the double-slash URL alias (see that patch for why).
-pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4cc82f5eff1ce2b515c7045eafee88f451dd14bb" }
-pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4cc82f5eff1ce2b515c7045eafee88f451dd14bb" }
+pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
+pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
 
 [patch."https://github.com/Far-Beyond-Pulsar/PBGC"]
 pbgc = { path = "crates/third-party/pbgc" }
@@ -342,9 +342,21 @@ wgsl_std = { path = "crates/third-party/psgc/crates/wgsl_std" }
 # a strict DESCENDANT of 9b887f1 -- flipping which side was stale and briefly
 # making this patch itself the outdated pin (SceneDB#39/Pulsar-Native#550
 # Phase A surfaced this: `#[engine_class(scene_store)]`'s `gpu`-feature path
-# wouldn't compile under the old 9b887f1 pin). Now 4cc82f5 (origin/main tip,
+# wouldn't compile under the old 9b887f1 pin). Then 4cc82f5 (origin/main tip,
 # PR #3 merged, additive-only per that PR) -- a strict descendant of both
-# 9b887f1 and b9dd888, so this collapses cleanly again either direction.
+# 9b887f1 and b9dd888, so this collapsed cleanly again either direction.
+#
+# NOW (TEMPORARY): d32ba8d, the tip of Pulsar-Reflection's unmerged
+# `typed-sync-component` branch -- Phase B2 of the SceneDB/Helio/reflection
+# unification plan (`.claude/plans/eager-plotting-lecun.md`), which types
+# `ComponentRuntimeBehavior::sync_component(component: &Self, ...)` instead
+# of `&serde_json::Value`. This is a breaking trait-signature change (unlike
+# Phase A's purely-additive `scene_store`), so bumping this pin and migrating
+# every real `#[register_runtime_behavior]` impl's signature
+# (`pulsar_rendering`/`pulsar_physics`, ~8 components) happened together, in
+# lockstep, in the same change -- see that plan's B2 section for why they
+# can't land separately. Durable fix: once `typed-sync-component` merges to
+# Pulsar-Reflection's `main`, repoint this rev there.
 #
 # The patch target URL and the replacement URL must be *different* source strings
 # or cargo rejects "points to the same source". The extra slash in
@@ -353,5 +365,5 @@ wgsl_std = { path = "crates/third-party/psgc/crates/wgsl_std" }
 # Durable fix: bump SceneDB's pulsar_reflection pin to match and cascade the rev,
 # then delete these patches.
 [patch."https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection"]
-pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4cc82f5eff1ce2b515c7045eafee88f451dd14bb" }
-pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "4cc82f5eff1ce2b515c7045eafee88f451dd14bb" }
+pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }
+pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "ece8e759c33ee7cc42127372117de8bec1636463" }

--- a/crates/core/engine_class_derive/Cargo.toml
+++ b/crates/core/engine_class_derive/Cargo.toml
@@ -36,13 +36,13 @@ gpu = []
 syn = { workspace = true, features = ["full", "extra-traits"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
-pulsar_reflection = { workspace = true }
-# NOT a real Rust-level dependency of this crate -- `::pulsar_scenedb::...`
-# only ever appears as a path *inside* `quote!{}`-generated token streams
-# (same as `::serde::Serialize` a few lines up), resolved later in whatever
-# crate compiles the derive's output. Kept out of [dependencies] on purpose;
-# see tests/scene_store_delegation.rs's [dev-dependencies] for where a real
-# one lives, to actually compile and run that generated code.
+# NOT a real Rust-level dependency of this crate -- every `pulsar_reflection::`/
+# `pulsar_scenedb::` reference in src/lib.rs is inside a `quote!{}`-generated
+# token stream (confirmed by grep: zero plain `use`/direct-code references),
+# same as `::serde::Serialize` a few lines below. Both are resolved later, in
+# whatever crate compiles the derive's output. Kept out of [dependencies] on
+# purpose; see [dev-dependencies] below for where real ones live, to actually
+# compile and run that generated code against this crate's own tests.
 
 [dev-dependencies]
 # TEMPORARY branch pin, not `workspace = true` or a local path: needs the
@@ -62,12 +62,15 @@ pulsar_reflection = { workspace = true }
 # `pulsar_scenedb`'s own `gpu`-gated modules need -- see the patch's own
 # comment in the root Cargo.toml for the version-skew history this closes).
 pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", branch = "engine-class-scenestore-export", features = ["gpu"] }
+pulsar_reflection = { workspace = true }
 # `#[engine_class]`'s generated methods call `tracing::warn!` unqualified --
 # every real consumer of this macro already has `tracing` in scope for that
 # reason; the test below is no exception.
 tracing = { workspace = true }
 wgpu = { workspace = true }
 pollster = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/core/engine_class_derive/src/lib.rs
+++ b/crates/core/engine_class_derive/src/lib.rs
@@ -429,12 +429,41 @@ pub fn engine_class(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let name = &item_struct.ident;
+    // Same deserialize-shim reasoning as `register_runtime_behavior`'s own
+    // codegen below (see its comment): `sync_component` is typed `&Self`,
+    // but `RuntimeBehaviorRegistration.sync` must be a concrete, non-generic
+    // `fn` pointer for `inventory::submit!` and still deals in
+    // `&serde_json::Value` (most callers only have JSON at dispatch time),
+    // so a small per-type shim bridges the two.
     let runtime_registration = if register_runtime {
+        let shim_fn_name = quote::format_ident!("__pulsar_reflection_sync_shim_{}", name);
         quote! {
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            fn #shim_fn_name(
+                owner: &pulsar_reflection::RuntimeComponentOwner,
+                component_index: usize,
+                component_data: &::serde_json::Value,
+                context: &mut dyn pulsar_reflection::ComponentRuntimeContext,
+            ) {
+                let parsed: #name = match ::serde_json::from_value(component_data.clone()) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        context.report_error(format!(
+                            "{} on '{}' is invalid: {error}",
+                            <#name as pulsar_reflection::ComponentRuntimeBehavior>::CLASS_NAME,
+                            owner.scene_object_id,
+                        ));
+                        return;
+                    }
+                };
+                <#name as pulsar_reflection::ComponentRuntimeBehavior>::sync_component(owner, component_index, &parsed, context);
+            }
+
             pulsar_reflection::inventory::submit! {
                 pulsar_reflection::RuntimeBehaviorRegistration {
                     class_name: <#name as pulsar_reflection::ComponentRuntimeBehavior>::CLASS_NAME,
-                    sync: <#name as pulsar_reflection::ComponentRuntimeBehavior>::sync_component,
+                    sync: #shim_fn_name,
                 }
             }
         }
@@ -484,12 +513,35 @@ pub fn engine_class(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn derive_register_runtime_behavior(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
+    let shim_fn_name = quote::format_ident!("__pulsar_reflection_sync_shim_{}", name);
 
     let generated = quote! {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        fn #shim_fn_name(
+            owner: &pulsar_reflection::RuntimeComponentOwner,
+            component_index: usize,
+            component_data: &::serde_json::Value,
+            context: &mut dyn pulsar_reflection::ComponentRuntimeContext,
+        ) {
+            let parsed: #name = match ::serde_json::from_value(component_data.clone()) {
+                Ok(value) => value,
+                Err(error) => {
+                    context.report_error(format!(
+                        "{} on '{}' is invalid: {error}",
+                        <#name as pulsar_reflection::ComponentRuntimeBehavior>::CLASS_NAME,
+                        owner.scene_object_id,
+                    ));
+                    return;
+                }
+            };
+            <#name as pulsar_reflection::ComponentRuntimeBehavior>::sync_component(owner, component_index, &parsed, context);
+        }
+
         pulsar_reflection::inventory::submit! {
             pulsar_reflection::RuntimeBehaviorRegistration {
                 class_name: <#name as pulsar_reflection::ComponentRuntimeBehavior>::CLASS_NAME,
-                sync: <#name as pulsar_reflection::ComponentRuntimeBehavior>::sync_component,
+                sync: #shim_fn_name,
             }
         }
     };
@@ -547,13 +599,57 @@ pub fn register_runtime_behavior(attr: TokenStream, item: TokenStream) -> TokenS
     }
 
     let self_ty = &impl_block.self_ty;
+    let Some(self_ty_ident) = (match &**self_ty {
+        syn::Type::Path(type_path) => type_path.path.segments.last().map(|s| &s.ident),
+        _ => None,
+    }) else {
+        return syn::Error::new_spanned(
+            self_ty,
+            "#[register_runtime_behavior] requires a simple named type (no generics, no qualified paths)",
+        )
+        .to_compile_error()
+        .into();
+    };
+    let shim_fn_name = quote::format_ident!("__pulsar_reflection_sync_shim_{}", self_ty_ident);
+
+    // `RuntimeBehaviorRegistration.sync` is a plain `fn` pointer (`inventory::
+    // submit!` needs a concrete static, not a generic) and still deals in
+    // `&serde_json::Value` (most callers -- e.g. a scene-file loader -- only
+    // have JSON on hand at dispatch time), while `sync_component` itself is
+    // typed `&Self` (see `ComponentRuntimeBehavior`'s doc in pulsar_reflection
+    // for why). This shim is the one deserialize call that bridges the two,
+    // generated here so component authors never hand-write JSON parsing. A
+    // parse failure is reported via `ComponentRuntimeContext::report_error`,
+    // not a panic.
     let output = quote! {
         #impl_block
+
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        fn #shim_fn_name(
+            owner: &pulsar_reflection::RuntimeComponentOwner,
+            component_index: usize,
+            component_data: &::serde_json::Value,
+            context: &mut dyn pulsar_reflection::ComponentRuntimeContext,
+        ) {
+            let parsed: #self_ty = match ::serde_json::from_value(component_data.clone()) {
+                Ok(value) => value,
+                Err(error) => {
+                    context.report_error(format!(
+                        "{} on '{}' is invalid: {error}",
+                        <#self_ty as pulsar_reflection::ComponentRuntimeBehavior>::CLASS_NAME,
+                        owner.scene_object_id,
+                    ));
+                    return;
+                }
+            };
+            <#self_ty as pulsar_reflection::ComponentRuntimeBehavior>::sync_component(owner, component_index, &parsed, context);
+        }
 
         pulsar_reflection::inventory::submit! {
             pulsar_reflection::RuntimeBehaviorRegistration {
                 class_name: <#self_ty as pulsar_reflection::ComponentRuntimeBehavior>::CLASS_NAME,
-                sync: <#self_ty as pulsar_reflection::ComponentRuntimeBehavior>::sync_component,
+                sync: #shim_fn_name,
             }
         }
     };

--- a/crates/core/engine_class_derive/tests/typed_runtime_behavior.rs
+++ b/crates/core/engine_class_derive/tests/typed_runtime_behavior.rs
@@ -1,0 +1,121 @@
+//! Phase B2 verification (see `.claude/plans/eager-plotting-lecun.md`,
+//! "B2 — `pulsar_reflection` typed `sync_component`"): proves the typed
+//! `ComponentRuntimeBehavior::sync_component(component: &Self, ...)` change
+//! dispatches correctly end to end -- `#[register_runtime_behavior]`'s
+//! generated shim deserializes the `&serde_json::Value` dispatch payload
+//! into the registered class's own concrete type exactly once, then calls
+//! the real typed `sync_component`, so the component's own body never
+//! touches JSON -- the same mechanism every real `pulsar_rendering`/
+//! `pulsar_physics` component now uses too (see the root `Cargo.toml`'s
+//! Pulsar-Reflection `[patch]` comment for that migration's own history).
+
+use engine_class_derive::register_runtime_behavior;
+use pulsar_reflection::{
+    apply_runtime_behavior_for_class, ComponentRuntimeBehavior, ComponentRuntimeContext,
+    RuntimeComponentOwner, Subsystems,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Default, Serialize, Deserialize)]
+struct ThrowawayRuntimeComponent {
+    value: u32,
+}
+
+#[register_runtime_behavior]
+impl ComponentRuntimeBehavior for ThrowawayRuntimeComponent {
+    const CLASS_NAME: &'static str = "ThrowawayRuntimeComponent";
+
+    fn sync_component(
+        owner: &RuntimeComponentOwner,
+        _component_index: usize,
+        component: &Self,
+        context: &mut dyn ComponentRuntimeContext,
+    ) {
+        // `component` is a genuinely typed `&Self` here -- no `.as_object()`/
+        // `.get(...)` dance in THIS function. The one JSON deserialize that
+        // got it here lives in the derive-generated shim, not here.
+        if owner.scene_object_id.is_empty() {
+            context.report_error("unexpected empty id".to_string());
+            return;
+        }
+        assert_eq!(component.value, 7, "sync_component must see the real typed value");
+    }
+}
+
+struct TestContext {
+    subsystems: Subsystems,
+    project_root: PathBuf,
+    errors: Vec<String>,
+}
+
+impl ComponentRuntimeContext for TestContext {
+    fn subsystems_mut(&mut self) -> &mut Subsystems {
+        &mut self.subsystems
+    }
+    fn project_root(&self) -> &Path {
+        &self.project_root
+    }
+    fn report_error(&mut self, message: String) {
+        self.errors.push(message);
+    }
+}
+
+fn test_context() -> TestContext {
+    TestContext { subsystems: Subsystems::new(), project_root: PathBuf::from("."), errors: Vec::new() }
+}
+
+fn owner(props: &HashMap<String, serde_json::Value>) -> RuntimeComponentOwner<'_> {
+    RuntimeComponentOwner {
+        scene_object_id: "throwaway-42",
+        position: [0.0; 3],
+        rotation: [0.0; 3],
+        scale: [1.0; 3],
+        props,
+    }
+}
+
+#[test]
+fn typed_sync_component_dispatches_through_inventory_registration() {
+    let props = HashMap::new();
+    let data = serde_json::to_value(ThrowawayRuntimeComponent { value: 7 }).unwrap();
+    let mut ctx = test_context();
+
+    let handled =
+        apply_runtime_behavior_for_class("ThrowawayRuntimeComponent", &owner(&props), 0, &data, &mut ctx);
+
+    assert!(handled, "registered class must be found and dispatched via inventory");
+    assert!(ctx.errors.is_empty(), "a correctly-typed dispatch must not report an error");
+}
+
+#[test]
+fn invalid_json_reports_an_error_not_a_panic() {
+    // A caller bug or a genuinely malformed scene file -- either way, a
+    // deserialize failure must not panic. The derive-generated shim's
+    // `serde_json::from_value` failing gracefully and reporting through
+    // `ComponentRuntimeContext::report_error` instead is the whole reason
+    // that shim exists rather than an unchecked `.unwrap()`.
+    let props = HashMap::new();
+    let data = serde_json::json!({ "value": "not a number" });
+    let mut ctx = test_context();
+
+    let handled =
+        apply_runtime_behavior_for_class("ThrowawayRuntimeComponent", &owner(&props), 0, &data, &mut ctx);
+
+    assert!(handled, "class_name still matches -- dispatch happens, the deserialize inside it fails");
+    assert_eq!(ctx.errors.len(), 1);
+    assert!(ctx.errors[0].contains("ThrowawayRuntimeComponent"), "error must name the class: {:?}", ctx.errors);
+}
+
+#[test]
+fn unregistered_class_name_is_not_handled() {
+    let props = HashMap::new();
+    let mut ctx = test_context();
+
+    let handled =
+        apply_runtime_behavior_for_class("NoSuchClass", &owner(&props), 0, &serde_json::Value::Null, &mut ctx);
+
+    assert!(!handled);
+    assert!(ctx.errors.is_empty());
+}

--- a/crates/subsystems/pulsar_physics/src/components/physics_component/runtime.rs
+++ b/crates/subsystems/pulsar_physics/src/components/physics_component/runtime.rs
@@ -1,6 +1,5 @@
 use engine_class_derive::register_runtime_behavior;
 use pulsar_reflection::{ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner};
-use serde_json::Value;
 
 use super::PhysicsComponent;
 
@@ -11,11 +10,12 @@ impl ComponentRuntimeBehavior for PhysicsComponent {
     fn sync_component(
         _owner: &RuntimeComponentOwner,
         _component_index: usize,
-        component_data: &Value,
+        _component: &Self,
         _context: &mut dyn ComponentRuntimeContext,
     ) {
-        let _physics = PhysicsComponent::from_component_data(component_data);
         // Runtime behavior: sync physics properties to the physics engine
-        // This is a placeholder for actual physics engine integration
+        // This is a placeholder for actual physics engine integration -- was
+        // already a no-op (deserialized-then-discarded) before this typed
+        // signature; `_component` is `&Self` now, nothing left to convert.
     }
 }

--- a/crates/subsystems/pulsar_physics/src/components/rigidbody_component/runtime.rs
+++ b/crates/subsystems/pulsar_physics/src/components/rigidbody_component/runtime.rs
@@ -1,6 +1,5 @@
 use engine_class_derive::register_runtime_behavior;
 use pulsar_reflection::{ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner};
-use serde_json::Value;
 
 use super::RigidbodyComponent;
 
@@ -11,11 +10,12 @@ impl ComponentRuntimeBehavior for RigidbodyComponent {
     fn sync_component(
         _owner: &RuntimeComponentOwner,
         _component_index: usize,
-        component_data: &Value,
+        _component: &Self,
         _context: &mut dyn ComponentRuntimeContext,
     ) {
-        let _rigidbody = RigidbodyComponent::from_component_data(component_data);
         // Runtime behavior: sync rigidbody properties to the physics engine
-        // This is a placeholder for actual physics engine integration
+        // This is a placeholder for actual physics engine integration -- was
+        // already a no-op (deserialized-then-discarded) before this typed
+        // signature; `_component` is `&Self` now, nothing left to convert.
     }
 }

--- a/crates/subsystems/pulsar_rendering/src/components/foliage_component/runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/foliage_component/runtime.rs
@@ -7,7 +7,6 @@ use pulsar_reflection::{
     RuntimeComponentOwner,
 };
 use serde::Serialize;
-use serde_json::Value;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -159,10 +158,9 @@ impl ComponentRuntimeBehavior for FoliageComponent {
     fn sync_component(
         owner: &RuntimeComponentOwner,
         component_index: usize,
-        component_data: &Value,
+        component: &Self,
         context: &mut dyn ComponentRuntimeContext,
     ) {
-        let component = Self::from_component_data(component_data);
         let key = format!("{}:{component_index}", owner.scene_object_id);
 
         // Mark live so the editor's post-sync stale pass keeps our handles.
@@ -182,8 +180,8 @@ impl ComponentRuntimeBehavior for FoliageComponent {
         }
 
         let material_hash = hash_props(&component.rendering);
-        let descriptor_hash = hash_props(&component);
-        let bounds_hash = bounds_hash(&component);
+        let descriptor_hash = hash_props(component);
+        let bounds_hash = bounds_hash(component);
         let wind_hash = hash_props(&component.wind);
 
         match cached {
@@ -205,12 +203,12 @@ impl ComponentRuntimeBehavior for FoliageComponent {
                         // what an edit to "where grass grows" must do.
                         let _ = scene.remove_foliage_layer(entry.layer_id);
                         entry.layer_id =
-                            scene.add_foliage_layer(build_layer(&component, entry.type_id, position));
+                            scene.add_foliage_layer(build_layer(component, entry.type_id, position));
                         entry.bounds_hash = bounds_hash;
                     }
                     if entry.descriptor_hash != descriptor_hash {
                         let material_id = if entry.material_hash != material_hash {
-                            let new_material = scene.insert_material(build_material(&component));
+                            let new_material = scene.insert_material(build_material(component));
                             let _ = scene.remove_material(entry.material_id);
                             new_material
                         } else {
@@ -218,10 +216,10 @@ impl ComponentRuntimeBehavior for FoliageComponent {
                         };
                         let _ = scene.update_foliage_type(
                             entry.type_id,
-                            build_type_descriptor(&component, material_id),
+                            build_type_descriptor(component, material_id),
                         );
                         if component.wind.wind_enabled && entry.wind_hash != wind_hash {
-                            apply_wind(scene, &component);
+                            apply_wind(scene, component);
                         }
                         entry.material_id = material_id;
                         entry.material_hash = material_hash;
@@ -255,11 +253,11 @@ impl ComponentRuntimeBehavior for FoliageComponent {
                     let renderer = get_subsystem!(context, Renderer);
                     let scene = renderer.scene_mut();
 
-                    let material_id = scene.insert_material(build_material(&component));
+                    let material_id = scene.insert_material(build_material(component));
                     let type_id =
-                        scene.add_foliage_type(build_type_descriptor(&component, material_id));
+                        scene.add_foliage_type(build_type_descriptor(component, material_id));
                     let layer_id =
-                        scene.add_foliage_layer(build_layer(&component, type_id, position));
+                        scene.add_foliage_layer(build_layer(component, type_id, position));
                     let interactor_position = if component.interaction.interactor_enabled {
                         position_v3
                     } else {
@@ -271,7 +269,7 @@ impl ComponentRuntimeBehavior for FoliageComponent {
                         velocity: glam::Vec3::ZERO,
                     });
                     if component.wind.wind_enabled {
-                        apply_wind(scene, &component);
+                        apply_wind(scene, component);
                     }
                     (type_id, layer_id, interactor_id, material_id)
                 };

--- a/crates/subsystems/pulsar_rendering/src/components/light_component/runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/light_component/runtime.rs
@@ -4,7 +4,6 @@ use pulsar_reflection::{
     get_subsystem, scene_id_to_tag, ComponentRuntimeBehavior, ComponentRuntimeContext,
     RuntimeComponentOwner,
 };
-use serde_json::Value;
 
 use super::{LightComponent, LightType};
 
@@ -15,10 +14,10 @@ impl ComponentRuntimeBehavior for LightComponent {
     fn sync_component(
         owner: &RuntimeComponentOwner,
         _component_index: usize,
-        component_data: &Value,
+        component: &Self,
         context: &mut dyn ComponentRuntimeContext,
     ) {
-        let light = Self::from_component_data(component_data);
+        let light = component;
         let tag = scene_id_to_tag(owner.scene_object_id);
 
         if !light.general.enabled {

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/runtime.rs
@@ -3,7 +3,6 @@ use pulsar_reflection::{
     ComponentRuntimeBehavior, ComponentRuntimeContext, LiveKeySet, RuntimeComponentOwner,
 };
 use pulsar_terrain::TerrainRuntimeHandle;
-use serde_json::Value;
 
 use super::{
     ComponentError, PLANET_TERRAIN_CLASS_NAME, PlanetTerrainComponent, PlanetTerrainComponentCache,
@@ -16,20 +15,9 @@ impl ComponentRuntimeBehavior for PlanetTerrainComponent {
     fn sync_component(
         owner: &RuntimeComponentOwner,
         component_index: usize,
-        component_data: &Value,
+        component: &Self,
         context: &mut dyn ComponentRuntimeContext,
     ) {
-        let component = match serde_json::from_value::<Self>(component_data.clone()) {
-            Ok(component) => component,
-            Err(error) => {
-                context.report_error(format!(
-                    "{PLANET_TERRAIN_CLASS_NAME} on '{}' is invalid: {error}",
-                    owner.scene_object_id
-                ));
-                return;
-            }
-        };
-
         // Component discovery is shared by editor and game contexts. The
         // production terrain runtime is registered only by hosts that have
         // enabled planetary terrain, so its absence is not a component error.
@@ -88,6 +76,7 @@ mod tests {
     use engine_subsystems::{Subsystem, SubsystemContext};
     use pulsar_reflection::{Subsystems, apply_runtime_behavior_for_class};
     use pulsar_terrain::{TerrainRuntimeConfig, TerrainSubsystem};
+    use serde_json::Value;
     use std::{
         collections::HashMap,
         path::{Path, PathBuf},

--- a/crates/subsystems/pulsar_rendering/src/components/portal_component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/portal_component.rs
@@ -22,7 +22,6 @@ use pulsar_reflection::{
     ComponentRuntimeBehavior, ComponentRuntimeContext, LiveKeySet, RuntimeComponentOwner,
     get_subsystem,
 };
-use serde_json::Value;
 
 use crate::subsystems::{PortalLinkCache, PortalSide, apply_portal_pair_action, portal_link_key};
 
@@ -73,20 +72,9 @@ impl ComponentRuntimeBehavior for PortalComponent {
     fn sync_component(
         owner: &RuntimeComponentOwner,
         _component_index: usize,
-        component_data: &Value,
+        component: &Self,
         context: &mut dyn ComponentRuntimeContext,
     ) {
-        let component = match serde_json::from_value::<Self>(component_data.clone()) {
-            Ok(c) => c,
-            Err(error) => {
-                context.report_error(format!(
-                    "{PORTAL_CLASS_NAME} on '{}' is invalid: {error}",
-                    owner.scene_object_id
-                ));
-                return;
-            }
-        };
-
         // Phase 1 — pure bookkeeping against `PortalLinkCache`: record (or
         // drop) this object's side and get back whatever action, if any, is
         // now needed to bring the real helio portal in sync. No `Renderer`

--- a/crates/subsystems/pulsar_rendering/src/components/script_component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/script_component.rs
@@ -253,16 +253,10 @@ impl ComponentRuntimeBehavior for ScriptComponent {
     fn sync_component(
         owner: &RuntimeComponentOwner,
         component_index: usize,
-        component_data: &Value,
+        component: &Self,
         context: &mut dyn ComponentRuntimeContext,
     ) {
-        let script_path = component_data
-            .as_object()
-            .and_then(|obj| obj.get("script_asset"))
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .unwrap_or_default()
-            .to_string();
+        let script_path = component.script_asset.as_str().trim().to_string();
 
         if script_path.is_empty() {
             context.report_error(format!(

--- a/crates/subsystems/pulsar_rendering/src/components/static_mesh_component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/static_mesh_component.rs
@@ -339,16 +339,10 @@ impl ComponentRuntimeBehavior for StaticMeshComponent {
     fn sync_component(
         owner: &RuntimeComponentOwner,
         _component_index: usize,
-        component_data: &Value,
+        component: &Self,
         context: &mut dyn ComponentRuntimeContext,
     ) {
-        let mesh_asset = component_data
-            .as_object()
-            .and_then(|obj| obj.get("mesh_asset"))
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .unwrap_or_default()
-            .to_string();
+        let mesh_asset = component.mesh_asset.as_str().trim().to_string();
 
         if mesh_asset.is_empty() {
             if !already_reported(owner.scene_object_id, "") {


### PR DESCRIPTION
Stacked on #550 (Phase A) -- targets that branch, not \`main\`, since this file (\`engine_class_derive\`) builds directly on it.

## What

\`ComponentRuntimeBehavior::sync_component(component: &Self, ...)\` replaces \`component_data: &Value\` -- no component implementation hand-parses JSON anymore. Migrated all 8 real \`#[register_runtime_behavior]\` impls (StaticMesh/Script/Portal/PlanetTerrain/Light/Foliage in \`pulsar_rendering\`, the two physics stubs in \`pulsar_physics\`) off \`.as_object().and_then(...)\` chains (or a manual \`from_component_data\`/\`serde_json::from_value::<Self>\` call at the top of the function) onto direct typed field access.

\`engine_class_derive\`'s three runtime-behavior registration codegens now generate a small deserialize-and-forward shim per component instead of assigning \`sync_component\`'s function pointer directly. The dispatch boundary (\`RuntimeBehaviorRegistration.sync\`/\`apply_runtime_behavior_for_class\`) deliberately stays on \`&serde_json::Value\` -- real callers like \`pulsar_scene::SceneLoader\` only have JSON on hand at dispatch time (that's [Phase B1](https://github.com/Far-Beyond-Pulsar/Pulsar-Native)'s job to change, not this one's) -- so the shim's one \`serde_json::from_value::<Self>\` call is now the single, centralized JSON boundary instead of one hand-rolled parser per component.

## Companion change

[Far-Beyond-Pulsar/Pulsar-Reflection#typed-sync-component](https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection/tree/typed-sync-component) (unmerged) -- the actual trait signature change. This is a breaking change (unlike Phase A's purely-additive \`scene_store\` flag), so bumping this workspace's Pulsar-Reflection pin and migrating all 8 real components happened together, in lockstep, in this one PR.

\`RuntimeComponentOwner.scene_object_id\` deliberately stays \`&str\` -- migrating it to a numeric/\`Entity\` identity is Phase B1's job, a separate change with its own blast radius across every owner-construction call site.

## Verification

- New \`tests/typed_runtime_behavior.rs\`: throwaway component covering the happy path, a malformed-JSON path (reports via \`ComponentRuntimeContext::report_error\`, doesn't panic), and an unregistered \`class_name\`.
- Full regression: \`pulsar_rendering\`, \`pulsar_physics\`, \`pulsar_scene\`, \`engine_backend\`, \`pulsar_game\`, \`ui_level_editor\` all compile clean.
- Every real test suite still passes, including \`pulsar_scene\`'s loader test -- which exercises the actual production JSON-loading path this change touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)