### PR TITLE
B3: undo/redo via whole-scene snapshots

### DIFF
--- a/crates/core/engine_backend/src/services/gpu_renderer.rs
+++ b/crates/core/engine_backend/src/services/gpu_renderer.rs
@@ -288,6 +288,18 @@ impl GpuRenderer {
         }
     }
 
+    /// Force the next scene sync to be a full (non-delta) pass. Callers must
+    /// call this after replacing `WorldSceneStore`'s contents wholesale
+    /// rather than through its normal mutators -- undo/redo
+    /// (Pulsar-Native#554) being the motivating case. See
+    /// `HelioRenderer::force_full_resync`'s doc for why this can't be
+    /// skipped.
+    pub fn force_full_resync(&mut self) {
+        if let Some(r) = &mut self.helio_renderer {
+            r.force_full_resync();
+        }
+    }
+
     /// Send a fire-and-forget command to the renderer thread (e.g. ToggleFeature).
     pub fn send_renderer_command(
         &self,

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -660,6 +660,30 @@ impl HelioRenderer {
         self.scene_store.read().get_selected_id()
     }
 
+    /// Force the next `sync_scene`/`sync_scene_delta` call to take the full
+    /// (non-delta) path, exactly as if this were the first frame.
+    ///
+    /// Needed after anything that replaces `WorldSceneStore` wholesale rather
+    /// than mutating it in place -- undo/redo (Pulsar-Native#554) being the
+    /// motivating case. `sync_scene_delta` diffs against `known_ids` and the
+    /// dirty/removed sets *of the store instance it's looking at right now*;
+    /// it has no way to notice that an entity present a moment ago in a
+    /// now-discarded store instance no longer exists. A full `sync_scene`
+    /// pass sidesteps that entirely -- it recomputes `live_keys` from
+    /// scratch and tears down anything in Helio's caches that isn't in it,
+    /// which is correct regardless of *how* an object disappeared.
+    ///
+    /// No-op if the renderer hasn't produced its first frame yet (`inner` is
+    /// `None`) -- that frame is already guaranteed to run a full sync by
+    /// construction (`last_scene_revision`/`known_ids` start at their
+    /// "first frame" values), so there's nothing to reset.
+    pub fn force_full_resync(&mut self) {
+        if let Some(inner) = &mut self.inner {
+            inner.last_scene_revision = 0;
+            inner.known_ids.clear();
+        }
+    }
+
     // ── Unified per-object scene mutations ────────────────────────────────────
     // These are called directly by SceneDatabase so every write path (user
     // actions, AI tools, content-drawer drops) hits Helio immediately instead

--- a/crates/editor/ui_level_editor/src/level_editor/core/commands.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/commands.rs
@@ -83,15 +83,36 @@ impl CommandResult {
 
 /// Apply `cmd` to `state`.
 ///
-/// Mutations go through `state.scene.database`, which writes to **both**
-/// `SceneDb` and the Helio renderer atomically.  `scene_revision` is bumped
-/// on every mutation, causing the polling task in `LevelEditorPanel` to notify
-/// the GPUI hierarchy and properties panels.
+/// Mutations go through `state.scene.database`, which writes to the shared
+/// `WorldSceneStore` the Helio renderer reads every frame.  `scene_revision`
+/// is bumped on every mutation, causing the polling task in
+/// `LevelEditorPanel` to notify the GPUI hierarchy and properties panels.
 ///
 /// GPUI-thread callers (panel action handlers) should additionally call
 /// `cx.notify()` after this returns.
+///
+/// Also the sole write path onto the undo stack (Pulsar-Native#554): for
+/// every variant except `SelectObject` (selection isn't undo-worthy), the
+/// scene's pre-command state is captured before running `cmd` and committed
+/// to `state.scene`'s undo history only if the command actually changed
+/// something (`CommandResult::changed`) -- a no-op command shouldn't leave a
+/// stale checkpoint an undo would just restore right back to. The match body
+/// below is unchanged from before this wiring; it's wrapped in an immediately-
+/// invoked closure purely so its several `return CommandResult::noop(...)`
+/// early-exits stay scoped to computing `result` instead of returning from
+/// this whole function before the checkpoint-commit step below runs.
 pub fn execute_command(state: &mut LevelEditorState, cmd: SceneCommand) -> CommandResult {
-    match cmd {
+    let is_undoable = !matches!(cmd, SceneCommand::SelectObject { .. });
+    let pre_state = is_undoable.then(|| state.scene.capture_history_snapshot());
+
+    // Reborrowed (not the outer `state` itself) so the `move` closure below
+    // can take ownership of this reborrow without moving the actual `state`
+    // parameter -- which is used again after the closure returns, to commit
+    // the checkpoint captured above.
+    let state_ref = &mut *state;
+    let result = (move || -> CommandResult {
+        let state = state_ref;
+        match cmd {
         SceneCommand::AddObject { data, parent_id } => {
             let id = state.scene.database.add_object(data, parent_id);
             state.scene.bump_revision(true);
@@ -219,5 +240,124 @@ pub fn execute_command(state: &mut LevelEditorState, cmd: SceneCommand) -> Comma
                 CommandResult::noop("Transform update failed")
             }
         }
+        }
+    })();
+
+    if result.changed {
+        if let Some(pre) = pre_state {
+            state.scene.commit_undo_checkpoint(pre);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod undo_redo_tests {
+    use super::*;
+    use crate::level_editor::scene_database::{ObjectType, SceneObjectData, Transform};
+
+    fn object(name: &str) -> SceneObjectData {
+        SceneObjectData {
+            id: String::new(),
+            name: name.to_string(),
+            object_type: ObjectType::Empty,
+            transform: Transform::default(),
+            visible: true,
+            locked: false,
+            parent: None,
+            children: vec![],
+            scene_path: String::new(),
+            props: Default::default(),
+            component_instances: None,
+        }
+    }
+
+    #[test]
+    fn undo_reverts_an_add_object_command() {
+        let mut state = LevelEditorState::new();
+        assert!(!state.scene.can_undo());
+
+        let result = execute_command(
+            &mut state,
+            SceneCommand::AddObject { data: object("Cube"), parent_id: None },
+        );
+        assert!(result.changed);
+        assert!(state.scene.can_undo());
+        assert_eq!(state.scene.database.get_all_objects().len(), 1);
+
+        assert!(state.scene.undo());
+        assert!(state.scene.database.get_all_objects().is_empty());
+        assert!(!state.scene.can_undo());
+        assert!(state.scene.can_redo());
+    }
+
+    #[test]
+    fn redo_reapplies_an_undone_command() {
+        let mut state = LevelEditorState::new();
+        execute_command(
+            &mut state,
+            SceneCommand::AddObject { data: object("Cube"), parent_id: None },
+        );
+        state.scene.undo();
+        assert!(state.scene.database.get_all_objects().is_empty());
+
+        assert!(state.scene.redo());
+
+        assert_eq!(state.scene.database.get_all_objects().len(), 1);
+        assert!(state.scene.can_undo());
+        assert!(!state.scene.can_redo());
+    }
+
+    #[test]
+    fn a_new_mutating_command_clears_the_redo_stack() {
+        let mut state = LevelEditorState::new();
+        execute_command(
+            &mut state,
+            SceneCommand::AddObject { data: object("A"), parent_id: None },
+        );
+        state.scene.undo();
+        assert!(state.scene.can_redo());
+
+        execute_command(
+            &mut state,
+            SceneCommand::AddObject { data: object("B"), parent_id: None },
+        );
+
+        assert!(!state.scene.can_redo());
+    }
+
+    #[test]
+    fn a_noop_command_does_not_push_an_undo_checkpoint() {
+        let mut state = LevelEditorState::new();
+        let result =
+            execute_command(&mut state, SceneCommand::RemoveObject { id: "nope".to_string() });
+        assert!(!result.changed);
+        assert!(!state.scene.can_undo());
+    }
+
+    #[test]
+    fn selecting_an_object_does_not_push_an_undo_checkpoint() {
+        let mut state = LevelEditorState::new();
+        let add = execute_command(
+            &mut state,
+            SceneCommand::AddObject { data: object("Cube"), parent_id: None },
+        );
+        let id = add.affected_ids[0].clone();
+        assert!(state.scene.can_undo()); // the AddObject checkpoint
+
+        execute_command(&mut state, SceneCommand::SelectObject { id: Some(id) });
+
+        // Still exactly the one checkpoint from AddObject -- undoing once
+        // now must remove the object, not merely revert the selection.
+        assert!(state.scene.undo());
+        assert!(state.scene.database.get_all_objects().is_empty());
+        assert!(!state.scene.can_undo());
+    }
+
+    #[test]
+    fn undo_and_redo_on_an_empty_history_are_no_ops() {
+        let mut state = LevelEditorState::new();
+        assert!(!state.scene.undo());
+        assert!(!state.scene.redo());
     }
 }

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -867,6 +867,75 @@ impl SceneDatabase {
             Self::collect_descendant_ids(store, child, out);
         }
     }
+
+    // ── Undo/redo (Pulsar-Native#554) ────────────────────────────────────
+    //
+    // Deliberately NOT built on `pulsar_scenedb::replication::Snapshot`
+    // (`capture_full`/`restore_to_world`): that machinery is shaped for
+    // network replication -- every component needs a registered
+    // `ReplicationRegistry` schema with per-field encode/decode `FieldOps`,
+    // which is real setup cost and a poor fit for `RenderProps`' free-form
+    // JSON (`HashMap<String, serde_json::Value>`, `Option<Value>`) -- not
+    // impossible, but a whole schema-registration subsystem to stand up for
+    // something `WorldSceneStore`'s own bridge already does. `to_snapshots`/
+    // `load_from_snapshots` already capture and round-trip everything a
+    // scene needs (proven by `world_store.rs`'s own tests), so undo/redo
+    // reuses that directly instead.
+
+    /// Capture a full, restorable snapshot of the current scene --
+    /// `WorldSceneStore`'s object/transform/hierarchy/render-props state
+    /// plus every object's reflection component data from `metadata_db`
+    /// (the two are captured together so a restore can't reintroduce one
+    /// half stale relative to the other). Treat the result as opaque; pass
+    /// it back to [`Self::restore_history_snapshot`] only.
+    pub fn capture_history_snapshot(&self) -> SceneHistorySnapshot {
+        let objects = self.store.read().to_snapshots();
+        let components = objects
+            .iter()
+            .map(|obj| (obj.stable_id.clone(), self.metadata_db.get_components(&obj.stable_id)))
+            .filter(|(_, components)| !components.is_empty())
+            .collect();
+        SceneHistorySnapshot { objects, components }
+    }
+
+    /// Restore a previously captured snapshot, replacing the current scene
+    /// entirely (`WorldSceneStore` is swapped for a fresh one built from the
+    /// snapshot; `metadata_db` is cleared and repopulated). Entity identity
+    /// is NOT preserved across a restore -- nothing outside `WorldSceneStore`
+    /// holds a raw `Entity` across calls (every `SceneDatabase` method
+    /// resolves `entity_for` fresh), so this is safe. Selection is cleared
+    /// (the fresh store has no `selected` entity) -- not preserving it is a
+    /// deliberate v1 simplification, not an oversight.
+    ///
+    /// Returns `Err` (leaving the live scene untouched) only if `snapshot`
+    /// itself is malformed -- a forward parent reference, which shouldn't
+    /// happen for a snapshot this type itself produced, but is surfaced
+    /// rather than silently no-op'd or panicking, since restoring a
+    /// generation-old snapshot after intervening schema changes is exactly
+    /// the kind of thing that's cheap to guard here and expensive to debug
+    /// if it silently corrupted the scene instead.
+    pub fn restore_history_snapshot(&self, snapshot: &SceneHistorySnapshot) -> Result<(), String> {
+        let new_store =
+            WorldSceneStore::load_from_snapshots(&snapshot.objects).map_err(|e| e.to_string())?;
+        *self.store.write() = new_store;
+        self.metadata_db.clear();
+        for (object_id, components) in &snapshot.components {
+            for component in components {
+                self.metadata_db
+                    .add_component_instance(object_id, component.clone());
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Opaque capture produced by [`SceneDatabase::capture_history_snapshot`],
+/// consumed by [`SceneDatabase::restore_history_snapshot`]. See that pair's
+/// docs for what it carries and why.
+#[derive(Clone, Debug)]
+pub struct SceneHistorySnapshot {
+    objects: Vec<engine_backend::scene::ObjectSnapshot>,
+    components: HashMap<ObjectId, Vec<ComponentInstance>>,
 }
 
 impl Default for SceneDatabase {
@@ -952,4 +1021,89 @@ fn find_script_path(props: &HashMap<String, Value>, component_instances: Option<
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string()
+}
+
+#[cfg(test)]
+mod history_snapshot_tests {
+    use super::*;
+
+    fn object(name: &str, object_type: ObjectType) -> SceneObjectData {
+        SceneObjectData {
+            id: String::new(),
+            name: name.to_string(),
+            object_type,
+            transform: Transform::default(),
+            visible: true,
+            locked: false,
+            parent: None,
+            children: vec![],
+            scene_path: String::new(),
+            props: Default::default(),
+            component_instances: None,
+        }
+    }
+
+    #[test]
+    fn capture_and_restore_round_trips_an_empty_scene() {
+        let db = SceneDatabase::new();
+        let snapshot = db.capture_history_snapshot();
+        db.add_folder("Should be undone", None);
+        assert_eq!(db.get_all_objects().len(), 1);
+
+        db.restore_history_snapshot(&snapshot).unwrap();
+
+        assert!(db.get_all_objects().is_empty());
+    }
+
+    #[test]
+    fn restore_brings_back_a_removed_object_with_its_transform() {
+        let db = SceneDatabase::new();
+        let mut obj = object("Cube", ObjectType::Mesh(MeshType::Cube));
+        obj.transform.position = [1.0, 2.0, 3.0];
+        let id = db.add_object(obj, None);
+
+        let snapshot = db.capture_history_snapshot();
+        db.remove_object(&id);
+        assert!(db.get_object(&id).is_none());
+
+        db.restore_history_snapshot(&snapshot).unwrap();
+
+        let restored = db.get_object(&id).expect("object restored");
+        assert_eq!(restored.name, "Cube");
+        assert_eq!(restored.transform.position, [1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn restore_brings_back_reflection_components() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Light", ObjectType::Light(LightType::Point)), None);
+        db.add_component(&id, "LightComponent".to_string(), serde_json::json!({"intensity": 5.0}));
+        assert_eq!(db.get_components(&id).len(), 1);
+
+        let snapshot = db.capture_history_snapshot();
+        db.remove_component(&id, 0);
+        assert!(db.get_components(&id).is_empty());
+
+        db.restore_history_snapshot(&snapshot).unwrap();
+
+        let components = db.get_components(&id);
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].class_name, "LightComponent");
+    }
+
+    #[test]
+    fn restore_preserves_hierarchy() {
+        let db = SceneDatabase::new();
+        let parent_id = db.add_object(object("Parent", ObjectType::Empty), None);
+        let child_id = db.add_object(object("Child", ObjectType::Empty), Some(parent_id.clone()));
+
+        let snapshot = db.capture_history_snapshot();
+        db.clear();
+        assert!(db.get_all_objects().is_empty());
+
+        db.restore_history_snapshot(&snapshot).unwrap();
+
+        let child = db.get_object(&child_id).expect("child restored");
+        assert_eq!(child.parent.as_deref(), Some(parent_id.as_str()));
+    }
 }

--- a/crates/editor/ui_level_editor/src/level_editor/state/scene.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/state/scene.rs
@@ -10,10 +10,17 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::level_editor::scene_database::{ObjectId, SceneObjectData};
+use crate::level_editor::scene_database::{ObjectId, SceneHistorySnapshot, SceneObjectData};
 use crate::level_editor::SceneDatabase;
 use engine_backend::scene::WorldSceneStore;
 use parking_lot::RwLock;
+
+/// Undo/redo history depth cap (Pulsar-Native#554). Each entry is a full
+/// scene snapshot (`SceneDatabase::capture_history_snapshot`'s cost is
+/// O(scene size) -- see that method's doc), so this bounds memory rather
+/// than letting an unbounded session-long history grow forever. Not tuned
+/// against a real project yet; a reasonable starting point for a v1.
+const MAX_UNDO_HISTORY: usize = 100;
 
 // ── Editor mode ────────────────────────────────────────────────────────────
 
@@ -52,6 +59,14 @@ pub struct SceneDomain {
     /// Monotonic revision counter — bumped on every mutation so pollers
     /// (and the observer system) can detect external changes.
     pub revision: u64,
+    /// Undo history (Pulsar-Native#554) — one entry per mutating
+    /// `SceneCommand` (`commands.rs::execute_command` pushes onto this),
+    /// oldest first. Bounded at [`MAX_UNDO_HISTORY`].
+    undo_stack: Vec<SceneHistorySnapshot>,
+    /// Redo history — populated by [`Self::undo`], cleared by every new
+    /// mutating command (standard undo/redo semantics: once you make a new
+    /// change, the old "future" you undid past is gone).
+    redo_stack: Vec<SceneHistorySnapshot>,
 }
 
 impl Default for SceneDomain {
@@ -64,6 +79,8 @@ impl Default for SceneDomain {
             current_scene: None,
             has_unsaved_changes: false,
             revision: 0,
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
         }
     }
 }
@@ -115,6 +132,84 @@ impl SceneDomain {
         if marks_unsaved {
             self.has_unsaved_changes = true;
         }
+    }
+
+    // ── Undo/redo (Pulsar-Native#554) ────────────────────────────────────
+    //
+    // v1, correctness-first: whole-scene snapshot per step, no per-command
+    // diffing. `commands.rs::execute_command` is the sole call site that
+    // pushes onto `undo_stack` -- it captures the pre-state before running a
+    // mutating command and commits it here only if the command actually
+    // changed something, so no-op commands and selection changes never
+    // clutter the history. `undo`/`redo` themselves are not run through
+    // `execute_command` -- they have their own pre/post semantics (push onto
+    // the *other* stack) that don't fit that flow.
+    //
+    // Note for callers driving the renderer (`panel.rs`'s `on_undo`/
+    // `on_redo`): a successful restore replaces `WorldSceneStore` wholesale,
+    // which the renderer's delta-sync path (`HelioRenderer::sync_scene_delta`)
+    // can't correctly diff against its own `known_ids`/cache state -- it was
+    // never told about entities that silently stopped existing because the
+    // whole store swapped rather than being individually despawned. Callers
+    // MUST force a full resync afterward (`GpuRenderer::force_full_resync`)
+    // or removed objects can be left behind in the Helio scene. See that
+    // method's doc.
+
+    /// Capture the scene's current state for later restore. Exposed so
+    /// `execute_command` can capture *before* running a command (the state
+    /// undo should return to), not after.
+    pub fn capture_history_snapshot(&self) -> SceneHistorySnapshot {
+        self.database.capture_history_snapshot()
+    }
+
+    /// Commit a previously captured pre-state onto the undo stack and clear
+    /// the redo stack. Called by `execute_command` only when the command it
+    /// preceded actually changed something.
+    pub fn commit_undo_checkpoint(&mut self, pre_state: SceneHistorySnapshot) {
+        self.undo_stack.push(pre_state);
+        if self.undo_stack.len() > MAX_UNDO_HISTORY {
+            self.undo_stack.remove(0);
+        }
+        self.redo_stack.clear();
+    }
+
+    pub fn can_undo(&self) -> bool {
+        !self.undo_stack.is_empty()
+    }
+
+    pub fn can_redo(&self) -> bool {
+        !self.redo_stack.is_empty()
+    }
+
+    /// Undo the last mutating command. Returns `true` if something was
+    /// undone (the caller should then force a renderer resync -- see this
+    /// section's top doc -- and bump the revision/mark unsaved, which this
+    /// method deliberately leaves to the caller since it has no `cx` to
+    /// notify with here).
+    pub fn undo(&mut self) -> bool {
+        let Some(previous) = self.undo_stack.pop() else { return false };
+        let current = self.database.capture_history_snapshot();
+        if self.database.restore_history_snapshot(&previous).is_err() {
+            // Restore failed (malformed snapshot) -- put it back so the
+            // entry isn't silently lost, and leave the redo stack alone.
+            self.undo_stack.push(previous);
+            return false;
+        }
+        self.redo_stack.push(current);
+        true
+    }
+
+    /// Redo the last undone command. See [`Self::undo`]'s doc for the
+    /// caller's responsibilities on success.
+    pub fn redo(&mut self) -> bool {
+        let Some(next) = self.redo_stack.pop() else { return false };
+        let current = self.database.capture_history_snapshot();
+        if self.database.restore_history_snapshot(&next).is_err() {
+            self.redo_stack.push(next);
+            return false;
+        }
+        self.undo_stack.push(current);
+        true
     }
 
     // ── Play mode ─────────────────────────────────────────────────────────

--- a/crates/editor/ui_level_editor/src/level_editor/ui/panel.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/ui/panel.rs
@@ -786,6 +786,39 @@ impl LevelEditorPanel {
         cx.notify();
     }
 
+    /// Undo the last mutating scene command (Pulsar-Native#554). Restoring
+    /// replaces `WorldSceneStore` wholesale, so the renderer's delta-sync
+    /// can't diff against it correctly -- `force_full_resync` is required
+    /// here, not optional; see its doc for why.
+    fn on_undo(&mut self, _: &super::actions::Undo, _: &mut Window, cx: &mut Context<Self>) {
+        let mut state = self.shared_state.write();
+        if state.scene.undo() {
+            state.scene.bump_revision(true);
+            drop(state);
+            if let Ok(mut engine) = self.gpu_engine.lock() {
+                engine.force_full_resync();
+            }
+            self.sync_gizmo_to_helio();
+        }
+        self.notify_sub_panels(cx);
+        cx.notify();
+    }
+
+    /// Redo the last undone scene command. See [`Self::on_undo`]'s doc.
+    fn on_redo(&mut self, _: &super::actions::Redo, _: &mut Window, cx: &mut Context<Self>) {
+        let mut state = self.shared_state.write();
+        if state.scene.redo() {
+            state.scene.bump_revision(true);
+            drop(state);
+            if let Ok(mut engine) = self.gpu_engine.lock() {
+                engine.force_full_resync();
+            }
+            self.sync_gizmo_to_helio();
+        }
+        self.notify_sub_panels(cx);
+        cx.notify();
+    }
+
     fn on_select_object(&mut self, action: &SelectObject, _: &mut Window, cx: &mut Context<Self>) {
         self.shared_state
             .write()
@@ -1303,6 +1336,8 @@ impl Render for LevelEditorPanel {
             .on_action(cx.listener(Self::on_add_object_of_type))
             .on_action(cx.listener(Self::on_delete_object))
             .on_action(cx.listener(Self::on_duplicate_object))
+            .on_action(cx.listener(Self::on_undo))
+            .on_action(cx.listener(Self::on_redo))
             .on_action(cx.listener(Self::on_select_object))
             .on_action(cx.listener(Self::on_toggle_object_expanded))
             .on_action(cx.listener(Self::on_focus_selected))


### PR DESCRIPTION
Implements [Pulsar-Native#554](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/issues/554) — v1, correctness-first undo/redo per the plan's design decision #4.

**Stacked on #562** — needs `WorldSceneStore`/`SceneDatabase`'s B1 cutover merged first.

## Design correction from the original plan

The plan pointed at `pulsar_scenedb::replication::Snapshot::capture_full`/`restore_to_world`. Read that API in full before using it: it requires every component registered in a `ReplicationRegistry` with per-field `FieldOps` encode/decode — built for network replication of typed fields, real setup cost, and a poor fit for `RenderProps`' free-form JSON. `WorldSceneStore`'s own `to_snapshots`/`load_from_snapshots` bridge already captures and round-trips everything a scene needs (proven by its own tests from B1), so undo/redo reuses that directly — no new dependencies, no schema registration.

## What's new

- `SceneDatabase::capture_history_snapshot`/`restore_history_snapshot` — captures `WorldSceneStore` state + every object's `metadata_db` component list together, so a restore can't reintroduce one half stale relative to the other.
- `SceneDomain` gains capped (100-entry) `undo_stack`/`redo_stack` + `undo`/`redo`/`can_undo`/`can_redo`.
- `execute_command` is the sole write path onto the undo stack: captures pre-state before a mutating command, commits only if it actually changed something, skips `SelectObject` entirely.
- **A real correctness fix, not a nice-to-have**: `HelioRenderer::force_full_resync`/`GpuRenderer::force_full_resync`. Restoring a snapshot replaces `WorldSceneStore` wholesale, which the renderer's delta-sync can't diff against correctly — it never learns an entity from the discarded store instance stopped existing. Without this, undoing an object add would leave it behind in the viewport.
- `on_undo`/`on_redo` GPUI action handlers, finally binding the long-declared-but-dead `Undo`/`Redo` actions.

Selection is deliberately not preserved across undo/redo (documented, not an oversight).

## Verification

- 10 new tests (4 on snapshot capture/restore, 6 on `execute_command`'s undo wiring) — all green.
- `engine_backend`: 52 tests. `ui_level_editor`: 27 tests (up from 17).
- `pulsar_engine` (the real editor binary) still builds clean.
- Not covered: actual GPUI keybinding dispatch (needs a window harness), selection preservation, per-command diffing (accepted v1 cost, optimizable later without an API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
