### PR TITLE
B4: World-backed component storage, proven on StaticMeshComponent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,8 @@ dependencies = [
  "pulsar_reflection",
  "pulsar_rendering",
  "pulsar_scene",
- "pulsar_scenedb",
+ "pulsar_scenedb 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=43921b0d432e99654161e1de65799fb65fa629f0)",
+ "pulsar_world_registry",
  "rapier3d",
  "reqwest 0.13.4",
  "ropey",
@@ -9119,6 +9120,7 @@ dependencies = [
  "pulsar_reflection",
  "pulsar_scenedb 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=43921b0d432e99654161e1de65799fb65fa629f0)",
  "pulsar_terrain",
+ "pulsar_world_registry",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -9230,6 +9232,17 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tracing",
+]
+
+[[package]]
+name = "pulsar_world_registry"
+version = "0.1.0"
+dependencies = [
+ "inventory",
+ "pulsar_reflection",
+ "pulsar_scenedb 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=43921b0d432e99654161e1de65799fb65fa629f0)",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -13551,6 +13564,7 @@ dependencies = [
  "pulsar_reflection",
  "pulsar_rendering",
  "pulsar_scenedb 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=43921b0d432e99654161e1de65799fb65fa629f0)",
+ "pulsar_world_registry",
  "raw-window-handle",
  "rfd",
  "rust-i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ pulsar_scenedb                     = { git = "https://github.com/Far-Beyond-Puls
 pulsar_reflection                  = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "4b489372bfb81607631c4ec8c7d7289efe709f40" }
 pulsar_events                      = { path = "crates/core/pulsar_events" }
 engine_class_derive                = { path = "crates/core/engine_class_derive" }
+pulsar_world_registry              = { path = "crates/core/pulsar_world_registry" }
 pulsar_scene                       = { path = "crates/subsystems/pulsar_scene" }
 pulsar_terrain                     = { path = "crates/subsystems/pulsar_terrain" }
 

--- a/crates/core/engine_backend/Cargo.toml
+++ b/crates/core/engine_backend/Cargo.toml
@@ -36,6 +36,7 @@ engine_state.workspace = true
 # scene store is moving onto this instead of the hand-rolled SceneDb/
 # SceneMetadataDb/ComponentDb in `src/scene/`. See `src/scene/world_store.rs`.
 pulsar_scenedb.workspace = true
+pulsar_world_registry.workspace = true
 
 # Shared scene loading — canonical implementation used by both engine and game
 pulsar_scene.workspace = true

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -1159,7 +1159,28 @@ impl HelioRenderer {
                 project_root: &project_root,
             };
 
+            // Phase B4/B5 (Pulsar-Native#555/#556): a class registered with
+            // `#[register_world_component]` dispatches directly off the
+            // typed value `SceneDatabase` already hydrated into `World` --
+            // no `serde_json::from_value` on this hot path. Falls back to
+            // the JSON dispatch below for anything not yet migrated (most of
+            // B5's list, at time of writing), or in the unexpected case
+            // hydration didn't happen for some reason -- fails safe rather
+            // than silently dropping the object's rendering.
+            let entity = store.entity_for(snap.stable_id.as_str());
             for (component_index, class_name, data) in component_instances {
+                if let Some(entity) = entity {
+                    if pulsar_world_registry::dispatch_world_component_for_class(
+                        class_name.as_str(),
+                        store.world(),
+                        entity,
+                        &owner,
+                        component_index,
+                        &mut ctx,
+                    ) {
+                        continue;
+                    }
+                }
                 let _ = apply_runtime_behavior_for_class(
                     class_name.as_str(),
                     &owner,

--- a/crates/core/engine_class_derive/src/lib.rs
+++ b/crates/core/engine_class_derive/src/lib.rs
@@ -657,6 +657,155 @@ pub fn register_runtime_behavior(attr: TokenStream, item: TokenStream) -> TokenS
     output.into()
 }
 
+/// Opt a component into `pulsar_world_registry`'s `World` bridge
+/// (Pulsar-Native#555/#556, Phase B4/B5): its typed value can be hydrated
+/// from JSON once per edit and inserted into `pulsar_scenedb::World`, then
+/// `HelioRenderer::sync_scene` dispatches `ComponentRuntimeBehavior::
+/// sync_component` directly off that typed value -- no per-frame
+/// `serde_json::from_value` for this component's class.
+///
+/// Applied *in addition to* `#[register_runtime_behavior]` (same `impl
+/// ComponentRuntimeBehavior for Type` block, stack both attributes) -- this
+/// is deliberately a separate, opt-in macro so migrating a component onto
+/// `World`-backed storage doesn't touch the already-shipped
+/// `RuntimeBehaviorRegistration`/JSON dispatch path at all. Components that
+/// haven't been migrated yet keep working exactly as before, through that
+/// unchanged path.
+///
+/// Same validation as `#[register_runtime_behavior]` -- see that macro's
+/// implementation for why each check exists; kept as a near-identical
+/// sibling rather than factored together, since the two attributes are
+/// meant to be readable and removable independently as B5 rolls out one
+/// component at a time.
+#[proc_macro_attribute]
+pub fn register_world_component(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new_spanned(
+            proc_macro2::TokenStream::from(attr),
+            "#[register_world_component] does not accept arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let impl_block = parse_macro_input!(item as ItemImpl);
+
+    if !impl_block.generics.params.is_empty() {
+        return syn::Error::new_spanned(
+            &impl_block.generics,
+            "#[register_world_component] does not support generic impl blocks",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let Some((_, trait_path, _)) = &impl_block.trait_ else {
+        return syn::Error::new_spanned(
+            &impl_block.self_ty,
+            "#[register_world_component] must be used on `impl ComponentRuntimeBehavior for Type`",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let Some(trait_ident) = trait_path.segments.last().map(|s| &s.ident) else {
+        return syn::Error::new_spanned(
+            trait_path,
+            "invalid trait path for #[register_world_component]",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    if trait_ident != "ComponentRuntimeBehavior" {
+        return syn::Error::new_spanned(
+            trait_path,
+            "#[register_world_component] must target `ComponentRuntimeBehavior` impl",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let self_ty = &impl_block.self_ty;
+    let Some(self_ty_ident) = (match &**self_ty {
+        syn::Type::Path(type_path) => type_path.path.segments.last().map(|s| &s.ident),
+        _ => None,
+    }) else {
+        return syn::Error::new_spanned(
+            self_ty,
+            "#[register_world_component] requires a simple named type (no generics, no qualified paths)",
+        )
+        .to_compile_error()
+        .into();
+    };
+    let hydrate_fn_name = quote::format_ident!("__pulsar_world_hydrate_{}", self_ty_ident);
+    let remove_fn_name = quote::format_ident!("__pulsar_world_remove_{}", self_ty_ident);
+    let dispatch_fn_name = quote::format_ident!("__pulsar_world_dispatch_{}", self_ty_ident);
+
+    // Note this macro does NOT emit `#impl_block` -- unlike
+    // `#[register_runtime_behavior]`, it's meant to be stacked alongside
+    // that macro on the same impl block, and only one of the two attributes
+    // on an item should re-emit the original block (attribute macros
+    // compose top-to-bottom; whichever runs first passes its output to the
+    // next, so re-emitting from both would duplicate the impl). Convention
+    // here: `#[register_runtime_behavior]` keeps ownership of emitting the
+    // block; `#[register_world_component]` is written *above* it and must
+    // only add new items.
+    let output = quote! {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        fn #hydrate_fn_name(
+            world: &mut pulsar_scenedb::World,
+            entity: pulsar_scenedb::Entity,
+            data: &::serde_json::Value,
+        ) -> ::std::result::Result<(), ::std::string::String> {
+            let parsed: #self_ty = ::serde_json::from_value(data.clone())
+                .map_err(|error| error.to_string())?;
+            world.insert(entity, parsed);
+            Ok(())
+        }
+
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        fn #remove_fn_name(world: &mut pulsar_scenedb::World, entity: pulsar_scenedb::Entity) {
+            let _ = world.remove::<#self_ty>(entity);
+        }
+
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        fn #dispatch_fn_name(
+            world: &pulsar_scenedb::World,
+            entity: pulsar_scenedb::Entity,
+            owner: &pulsar_reflection::RuntimeComponentOwner,
+            component_index: usize,
+            context: &mut dyn pulsar_reflection::ComponentRuntimeContext,
+        ) -> bool {
+            match world.get::<#self_ty>(entity) {
+                Some(component) => {
+                    <#self_ty as pulsar_reflection::ComponentRuntimeBehavior>::sync_component(
+                        owner, component_index, component, context,
+                    );
+                    true
+                }
+                None => false,
+            }
+        }
+
+        pulsar_world_registry::inventory::submit! {
+            pulsar_world_registry::WorldComponentRegistration {
+                class_name: <#self_ty as pulsar_reflection::ComponentRuntimeBehavior>::CLASS_NAME,
+                hydrate: #hydrate_fn_name,
+                remove: #remove_fn_name,
+                dispatch: #dispatch_fn_name,
+            }
+        }
+
+        #impl_block
+    };
+
+    output.into()
+}
+
 #[proc_macro_attribute]
 pub fn register_scene_props_applier(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {

--- a/crates/core/pulsar_world_registry/Cargo.toml
+++ b/crates/core/pulsar_world_registry/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pulsar_world_registry"
+version = "0.1.0"
+edition = "2021"
+description = "Class-name-keyed registry bridging reflection-typed, ComponentRuntimeBehavior-implementing components into pulsar_scenedb::World -- hydrate JSON into a typed World component once per edit (not per render frame), then dispatch sync_component directly off that typed value."
+
+[dependencies]
+pulsar_scenedb    = { workspace = true }
+pulsar_reflection = { workspace = true }
+serde_json        = { workspace = true }
+inventory         = { workspace = true }
+
+[dev-dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/core/pulsar_world_registry/src/lib.rs
+++ b/crates/core/pulsar_world_registry/src/lib.rs
@@ -1,0 +1,307 @@
+//! Bridges reflection-typed, [`pulsar_reflection::ComponentRuntimeBehavior`]-
+//! implementing components into `pulsar_scenedb::World` (Pulsar-Native#555/
+//! #556, Phase B4/B5 of the SceneDB + Helio + reflection/properties-panel
+//! unification -- see [Pulsar-Native#561](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/issues/561)).
+//!
+//! ## What this solves
+//!
+//! Before this crate, a component's *live* runtime shape was always
+//! `serde_json::Value`: `HelioRenderer::sync_scene` re-deserialized every
+//! component's JSON into its typed struct on *every rendered frame* (via
+//! `apply_runtime_behavior_for_class`), even though `#[register_runtime_behavior]`
+//! (Phase B2) already made `ComponentRuntimeBehavior::sync_component` itself
+//! typed -- the JSON round trip was purely an artifact of the dispatch
+//! boundary, not the trait.
+//!
+//! `#[register_world_component]` (`engine_class_derive`) lets a component opt
+//! into this crate's registry, which provides:
+//! - **`hydrate`**: deserialize a component's JSON *once*, when it's
+//!   actually edited (`SceneDatabase`'s component-mutation hook), and insert
+//!   the typed value into `World` at that entity.
+//! - **`dispatch`**: read the typed value already sitting in `World` and call
+//!   `ComponentRuntimeBehavior::sync_component` directly -- no JSON, no
+//!   `serde_json::from_value` -- on the render hot path.
+//! - **`remove`**: drop the typed value when the component is deleted,
+//!   disabled, or its owning object is despawned.
+//!
+//! ## Why this crate exists instead of extending `pulsar_reflection` directly
+//!
+//! `pulsar_reflection` is a separate repository, also used by non-SceneDB
+//! contexts (the Blueprint and shader editors reuse its property-reflection
+//! machinery), so it deliberately has no dependency on `pulsar_scenedb`.
+//! `pulsar_scenedb` is *also* a separate repository, and Pulsar-Native's pin
+//! of it is currently stuck (Pulsar-Native#560, blocked on
+//! [SceneDB#46](https://github.com/Far-Beyond-Pulsar/SceneDB/issues/46)) --
+//! landing new SceneDB-repo code and getting it pulled into this workspace
+//! is real, avoidable friction right now. Every actual consumer here
+//! (`pulsar_rendering`, `pulsar_physics`, `engine_backend`, `ui_level_editor`)
+//! already depends on both `pulsar_scenedb` and `pulsar_reflection` directly,
+//! so a small Pulsar-Native-internal crate sitting alongside them -- itself
+//! depending on both -- is a clean fit with no cross-repo coordination
+//! needed at all.
+//!
+//! ## Why a separate registry from `RuntimeBehaviorRegistration`
+//!
+//! `pulsar_reflection::RuntimeBehaviorRegistration`/`apply_runtime_behavior_for_class`
+//! stay exactly as they are (JSON-based) -- they're still the dispatch path
+//! for anything that only has JSON on hand (`pulsar_scene::SceneLoader`, and
+//! any component that hasn't been migrated onto this registry yet, e.g. the
+//! rest of B5's list before it lands). Migration is opt-in and incremental,
+//! one component at a time, which is exactly why this is a sibling registry
+//! rather than a breaking change to the existing one.
+
+// Re-exported so `#[register_world_component]` (`engine_class_derive`) can
+// emit `pulsar_world_registry::inventory::submit! { .. }` in the calling
+// crate without that crate needing its own direct `inventory` dependency --
+// same pattern `pulsar_reflection` already uses for `RuntimeBehaviorRegistration`.
+pub use inventory;
+
+use pulsar_reflection::{ComponentRuntimeContext, RuntimeComponentOwner};
+use pulsar_scenedb::{Entity, World};
+use serde_json::Value;
+
+/// One registered component class's `World` bridge. Populated by
+/// `#[register_world_component]` (`engine_class_derive`) -- not constructed
+/// by hand.
+pub struct WorldComponentRegistration {
+    pub class_name: &'static str,
+    /// Deserialize `data` and insert/overwrite this class's typed component
+    /// on `entity`. Called once per edit (from `SceneDatabase`'s component
+    /// mutation hook), never from the render loop.
+    pub hydrate: fn(&mut World, Entity, &Value) -> Result<(), String>,
+    /// Remove this class's typed component from `entity`, if present.
+    /// Called when the component is deleted, disabled, or its owning object
+    /// is despawned.
+    pub remove: fn(&mut World, Entity),
+    /// Dispatch `ComponentRuntimeBehavior::sync_component` using the typed
+    /// value already in `World` -- no JSON deserialize on this path at all.
+    /// Returns `false` (and does nothing) if `entity` doesn't have this
+    /// component in `World` (not hydrated yet); callers should fall back to
+    /// `pulsar_reflection::apply_runtime_behavior_for_class` in that case,
+    /// which still works off the JSON channel unconditionally.
+    pub dispatch: fn(
+        &World,
+        Entity,
+        &RuntimeComponentOwner,
+        usize,
+        &mut dyn ComponentRuntimeContext,
+    ) -> bool,
+}
+
+inventory::collect!(WorldComponentRegistration);
+
+fn find(class_name: &str) -> Option<&'static WorldComponentRegistration> {
+    inventory::iter::<WorldComponentRegistration>
+        .into_iter()
+        .find(|r| r.class_name == class_name)
+}
+
+/// Hydrate `class_name`'s typed component from `data` onto `entity`. Returns
+/// `Ok(false)` if `class_name` isn't registered here (not migrated yet, or
+/// not a real component class) -- not an error, it just means the JSON
+/// channel stays authoritative for this class. Returns `Err` only if
+/// `class_name` *is* registered but `data` failed to deserialize.
+pub fn hydrate_world_component_for_class(
+    class_name: &str,
+    world: &mut World,
+    entity: Entity,
+    data: &Value,
+) -> Result<bool, String> {
+    match find(class_name) {
+        Some(registration) => (registration.hydrate)(world, entity, data).map(|()| true),
+        None => Ok(false),
+    }
+}
+
+/// Remove `class_name`'s typed component from `entity`, if that class is
+/// registered here. Returns `false` if `class_name` isn't registered.
+pub fn remove_world_component_for_class(class_name: &str, world: &mut World, entity: Entity) -> bool {
+    match find(class_name) {
+        Some(registration) => {
+            (registration.remove)(world, entity);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Dispatch `class_name`'s `ComponentRuntimeBehavior::sync_component`
+/// directly off `entity`'s typed `World` value, if that class is registered
+/// here and hydrated on `entity`. Returns `false` otherwise -- callers
+/// should fall back to `pulsar_reflection::apply_runtime_behavior_for_class`.
+pub fn dispatch_world_component_for_class(
+    class_name: &str,
+    world: &World,
+    entity: Entity,
+    owner: &RuntimeComponentOwner,
+    component_index: usize,
+    context: &mut dyn ComponentRuntimeContext,
+) -> bool {
+    match find(class_name) {
+        Some(registration) => (registration.dispatch)(world, entity, owner, component_index, context),
+        None => false,
+    }
+}
+
+/// Every currently-registered `World`-backed class name. `SceneDatabase`
+/// uses this to know which classes to check for removal when an object's
+/// component list changes -- a class present in `World` from a previous
+/// hydration but no longer in the object's current enabled component list
+/// needs `remove` called, and this is how it finds out which classes to
+/// even ask about.
+pub fn registered_world_component_classes() -> impl Iterator<Item = &'static str> {
+    inventory::iter::<WorldComponentRegistration>
+        .into_iter()
+        .map(|r| r.class_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize)]
+    struct TestComponent {
+        value: i32,
+    }
+
+    fn test_hydrate(world: &mut World, entity: Entity, data: &Value) -> Result<(), String> {
+        let parsed: TestComponent = serde_json::from_value(data.clone()).map_err(|e| e.to_string())?;
+        world.insert(entity, parsed);
+        Ok(())
+    }
+
+    fn test_remove(world: &mut World, entity: Entity) {
+        let _ = world.remove::<TestComponent>(entity);
+    }
+
+    fn test_dispatch(
+        world: &World,
+        entity: Entity,
+        _owner: &RuntimeComponentOwner,
+        _component_index: usize,
+        _context: &mut dyn ComponentRuntimeContext,
+    ) -> bool {
+        world.get::<TestComponent>(entity).is_some()
+    }
+
+    inventory::submit! {
+        WorldComponentRegistration {
+            class_name: "TestComponent",
+            hydrate: test_hydrate,
+            remove: test_remove,
+            dispatch: test_dispatch,
+        }
+    }
+
+    struct DummyContext {
+        subsystems: pulsar_reflection::Subsystems,
+    }
+
+    impl ComponentRuntimeContext for DummyContext {
+        fn subsystems_mut(&mut self) -> &mut pulsar_reflection::Subsystems {
+            &mut self.subsystems
+        }
+        fn project_root(&self) -> &std::path::Path {
+            std::path::Path::new(".")
+        }
+        fn report_error(&mut self, _message: String) {}
+    }
+
+    fn dummy_context() -> DummyContext {
+        DummyContext { subsystems: pulsar_reflection::Subsystems::new() }
+    }
+
+    fn dummy_owner(props: &HashMap<String, Value>) -> RuntimeComponentOwner<'_> {
+        RuntimeComponentOwner {
+            scene_object_id: "test",
+            position: [0.0; 3],
+            rotation: [0.0; 3],
+            scale: [1.0; 3],
+            props,
+        }
+    }
+
+    #[test]
+    fn registered_test_component_is_discoverable() {
+        assert!(registered_world_component_classes().any(|c| c == "TestComponent"));
+    }
+
+    #[test]
+    fn hydrate_dispatch_remove_round_trip() {
+        let mut world = World::new();
+        let entity = world.spawn();
+        let props = HashMap::new();
+        let mut ctx = dummy_context();
+
+        // Not hydrated yet -- dispatch is a clean no-op, not a panic.
+        assert!(!dispatch_world_component_for_class(
+            "TestComponent", &world, entity, &dummy_owner(&props), 0, &mut ctx
+        ));
+
+        let hydrated = hydrate_world_component_for_class(
+            "TestComponent", &mut world, entity, &serde_json::json!({"value": 42}),
+        )
+        .unwrap();
+        assert!(hydrated);
+        assert_eq!(world.get::<TestComponent>(entity), Some(&TestComponent { value: 42 }));
+
+        assert!(dispatch_world_component_for_class(
+            "TestComponent", &world, entity, &dummy_owner(&props), 0, &mut ctx
+        ));
+
+        assert!(remove_world_component_for_class("TestComponent", &mut world, entity));
+        assert!(world.get::<TestComponent>(entity).is_none());
+    }
+
+    #[test]
+    fn unregistered_class_is_a_clean_no_op_everywhere() {
+        let mut world = World::new();
+        let entity = world.spawn();
+        let props = HashMap::new();
+        let mut ctx = dummy_context();
+
+        assert_eq!(
+            hydrate_world_component_for_class(
+                "NotRegistered", &mut world, entity, &serde_json::json!({})
+            )
+            .unwrap(),
+            false
+        );
+        assert!(!remove_world_component_for_class("NotRegistered", &mut world, entity));
+        assert!(!dispatch_world_component_for_class(
+            "NotRegistered", &world, entity, &dummy_owner(&props), 0, &mut ctx
+        ));
+    }
+
+    #[test]
+    fn hydrate_surfaces_malformed_json_as_an_error() {
+        let mut world = World::new();
+        let entity = world.spawn();
+
+        let err = hydrate_world_component_for_class(
+            "TestComponent", &mut world, entity, &serde_json::json!("not an object"),
+        )
+        .unwrap_err();
+        assert!(!err.is_empty());
+        // A failed hydrate must not leave a half-inserted component behind.
+        assert!(world.get::<TestComponent>(entity).is_none());
+    }
+
+    #[test]
+    fn hydrate_overwrites_a_previous_value() {
+        let mut world = World::new();
+        let entity = world.spawn();
+
+        hydrate_world_component_for_class(
+            "TestComponent", &mut world, entity, &serde_json::json!({"value": 1}),
+        )
+        .unwrap();
+        hydrate_world_component_for_class(
+            "TestComponent", &mut world, entity, &serde_json::json!({"value": 2}),
+        )
+        .unwrap();
+
+        assert_eq!(world.get::<TestComponent>(entity), Some(&TestComponent { value: 2 }));
+    }
+}

--- a/crates/editor/ui_level_editor/Cargo.toml
+++ b/crates/editor/ui_level_editor/Cargo.toml
@@ -18,6 +18,7 @@ plugin_editor_api.workspace = true
 anyhow.workspace = true
 tool_registry = { workspace = true }
 pulsar_scenedb = { workspace = true }
+pulsar_world_registry = { workspace = true }
 
 # Engine
 engine_state.workspace = true

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -857,6 +857,45 @@ impl SceneDatabase {
                 .collect();
             render_props.component_instances = Some(Value::Array(instances));
         });
+
+        // Phase B4/B5 (Pulsar-Native#555/#556): hydrate or remove each
+        // World-backed component's typed value to match this object's
+        // current enabled component list, so HelioRenderer::sync_scene can
+        // dispatch ComponentRuntimeBehavior::sync_component directly off
+        // World -- no per-frame JSON deserialize for migrated classes. Runs
+        // over every *registered* class (not just ones this object
+        // currently has) so a component that was just removed or disabled
+        // gets its stale typed World value dropped, not merely skipped on
+        // the next hydration.
+        if let Some(entity) = store.entity_for(object_id) {
+            for class_name in pulsar_world_registry::registered_world_component_classes() {
+                let enabled_data = components
+                    .iter()
+                    .find(|c| c.class_name == class_name && c.enabled)
+                    .map(|c| &c.data);
+                match enabled_data {
+                    Some(data) => {
+                        if let Err(error) = pulsar_world_registry::hydrate_world_component_for_class(
+                            class_name,
+                            store.world_mut(),
+                            entity,
+                            data,
+                        ) {
+                            tracing::warn!(
+                                "World hydration failed for {class_name} on '{object_id}': {error}"
+                            );
+                        }
+                    }
+                    None => {
+                        pulsar_world_registry::remove_world_component_for_class(
+                            class_name,
+                            store.world_mut(),
+                            entity,
+                        );
+                    }
+                }
+            }
+        }
     }
 
     fn collect_descendant_ids(store: &WorldSceneStore, entity: Entity, out: &mut Vec<ObjectId>) {
@@ -1105,5 +1144,131 @@ mod history_snapshot_tests {
 
         let child = db.get_object(&child_id).expect("child restored");
         assert_eq!(child.parent.as_deref(), Some(parent_id.as_str()));
+    }
+}
+
+/// Phase B4 (Pulsar-Native#555): proves `StaticMeshComponent` -- the first
+/// component migrated onto `pulsar_world_registry`'s `World` bridge --
+/// actually gets hydrated/removed through the real `SceneDatabase` wiring,
+/// not just the synthetic fixture `pulsar_world_registry`'s own unit tests
+/// use. Reaches into `db.store` directly (a private field) -- valid since
+/// this module is a descendant of `scene_database`, not external code
+/// working through the public API only.
+#[cfg(test)]
+mod world_component_hydration_tests {
+    use super::*;
+    use pulsar_rendering::StaticMeshComponent;
+
+    fn object(name: &str) -> SceneObjectData {
+        SceneObjectData {
+            id: String::new(),
+            name: name.to_string(),
+            object_type: ObjectType::Mesh(MeshType::Custom),
+            transform: Transform::default(),
+            visible: true,
+            locked: false,
+            parent: None,
+            children: vec![],
+            scene_path: String::new(),
+            props: Default::default(),
+            component_instances: None,
+        }
+    }
+
+    #[test]
+    fn add_component_hydrates_the_typed_world_value() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+
+        db.add_component(
+            &id,
+            "StaticMeshComponent".to_string(),
+            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+        );
+
+        let store = db.store.read();
+        let entity = store.entity_for(&id).unwrap();
+        let hydrated = store.world().get::<StaticMeshComponent>(entity).unwrap();
+        assert_eq!(hydrated.mesh_asset.as_str(), "meshes/primitives/SM_Cube.fbx");
+    }
+
+    #[test]
+    fn update_component_property_re_hydrates_the_typed_value() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+        db.add_component(
+            &id,
+            "StaticMeshComponent".to_string(),
+            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+        );
+
+        db.update_component_property(
+            &id,
+            "StaticMeshComponent",
+            "mesh_asset",
+            serde_json::json!("meshes/primitives/SM_Sphere.fbx"),
+        );
+
+        let store = db.store.read();
+        let entity = store.entity_for(&id).unwrap();
+        let hydrated = store.world().get::<StaticMeshComponent>(entity).unwrap();
+        assert_eq!(hydrated.mesh_asset.as_str(), "meshes/primitives/SM_Sphere.fbx");
+    }
+
+    #[test]
+    fn remove_component_drops_the_typed_world_value() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+        db.add_component(
+            &id,
+            "StaticMeshComponent".to_string(),
+            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+        );
+        {
+            let store = db.store.read();
+            let entity = store.entity_for(&id).unwrap();
+            assert!(store.world().get::<StaticMeshComponent>(entity).is_some());
+        }
+
+        db.remove_component(&id, 0);
+
+        let store = db.store.read();
+        let entity = store.entity_for(&id).unwrap();
+        assert!(store.world().get::<StaticMeshComponent>(entity).is_none());
+    }
+
+    #[test]
+    fn disabling_a_component_drops_the_typed_world_value() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+        db.add_component(
+            &id,
+            "StaticMeshComponent".to_string(),
+            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+        );
+
+        db.set_component_enabled(&id, 0, false);
+
+        let store = db.store.read();
+        let entity = store.entity_for(&id).unwrap();
+        assert!(store.world().get::<StaticMeshComponent>(entity).is_none());
+    }
+
+    #[test]
+    fn malformed_component_json_does_not_hydrate_but_does_not_panic() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+
+        // `mesh_asset` should be a string; this is a type mismatch, not a
+        // missing field, so it should fail hydration cleanly.
+        db.add_component(
+            &id,
+            "StaticMeshComponent".to_string(),
+            serde_json::json!({"mesh_asset": 12345}),
+        );
+
+        let store = db.store.read();
+        let entity = store.entity_for(&id).unwrap();
+        assert!(store.world().get::<StaticMeshComponent>(entity).is_none());
     }
 }

--- a/crates/subsystems/pulsar_rendering/Cargo.toml
+++ b/crates/subsystems/pulsar_rendering/Cargo.toml
@@ -16,6 +16,7 @@ engine_class_derive = { workspace = true }
 pulsar_reflection = { workspace = true, features = ["prims-gpui"] }
 pulsar_events = { workspace = true }
 pulsar_scenedb = { workspace = true }
+pulsar_world_registry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/subsystems/pulsar_rendering/src/components/static_mesh_component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/static_mesh_component.rs
@@ -1,6 +1,8 @@
 //! Static mesh component for mesh asset assignment.
 
-use engine_class_derive::{engine_class, register_runtime_behavior, register_scene_props_applier};
+use engine_class_derive::{
+    engine_class, register_runtime_behavior, register_scene_props_applier, register_world_component,
+};
 use glam::{EulerRot, Mat4, Quat, Vec3};
 use helio::{GpuMaterial, GroupMask, Movability, ObjectDescriptor, Renderer, SceneActor};
 use pulsar_reflection::{
@@ -332,6 +334,12 @@ impl ScenePropsProjector for StaticMeshComponent {
     }
 }
 
+// Phase B4 (Pulsar-Native#555): the first component migrated onto
+// pulsar_world_registry's World bridge -- proves the pattern before B5
+// rolls it out to the rest. `#[register_world_component]` must be written
+// above `#[register_runtime_behavior]` (see that macro's own doc for why:
+// only the bottom attribute in the stack re-emits the impl block).
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for StaticMeshComponent {
     const CLASS_NAME: &'static str = "StaticMeshComponent";


### PR DESCRIPTION
Implements [Pulsar-Native#555](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/issues/555).

## Design correction from the original plan

The issue pointed at `helio-scenedb`'s `HelioRenderSubsystem`/`ChangeTracker` mechanism as the intended path. Checked before writing code: that mechanism is referenced only inside its own crate (`crates/renderer/helio/crates/helio-scenedb/`) — zero hits anywhere in `engine_backend`/`ui_level_editor`/`pulsar_rendering`. It was never actually wired into the live editor renderer. The issue also correctly flagged that `helio-scenedb`'s own `StaticMeshComponent` is a *different struct* from `pulsar_rendering`'s — routing through it would mean rebuilding asset-path resolution that already exists.

Given `pulsar_rendering`'s components already have typed `sync_component` (B2, merged) and are what `HelioRenderer::sync_scene` actually dispatches today, I extended that live path instead of integrating the disconnected one. Full writeup in the commit message.

## What's new

- **`pulsar_world_registry`** (new crate) — class-name-keyed registry providing `hydrate`/`remove`/`dispatch` for components opted into `World`-backed storage. Lives in Pulsar-Native (not `pulsar_reflection` or `pulsar_scenedb`, both separate repos with their own reasons not to take this on — see the crate's doc comment) — no cross-repo coordination needed.
- **`#[register_world_component]`** (`engine_class_derive`) — opt-in sibling to `#[register_runtime_behavior]`, stacked on the same impl block. Generates hydrate/remove/dispatch shims.
- **`StaticMeshComponent`** — first component migrated.
- **`SceneDatabase`**'s existing component-mutation hook now also hydrates/removes each registered class's typed value.
- **`HelioRenderer::sync_scene`** tries typed `World` dispatch first, falls back to the existing JSON path for anything not yet migrated (all of B5's list, for now).

## Verification

10 new tests (5 on the registry mechanism, 5 proving the real wiring end-to-end through `StaticMeshComponent` specifically). Full regression: `engine_backend` (52), `pulsar_rendering` (19), `pulsar_world_registry` (5), `ui_level_editor` (32) all green. `pulsar_engine` (the real editor binary) builds clean.

Not done: manual editor smoke test (place a static mesh, edit its mesh asset, confirm the viewport updates) — same category B1/B3 needed a human for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
