### PR TITLE
B5: migrate the remaining 7 real components onto World-backed storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9061,6 +9061,7 @@ dependencies = [
  "engine_class_derive",
  "pulsar_reflection",
  "pulsar_scenedb 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=43921b0d432e99654161e1de65799fb65fa629f0)",
+ "pulsar_world_registry",
  "serde",
  "serde_json",
  "tracing",

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -1271,4 +1271,50 @@ mod world_component_hydration_tests {
         let entity = store.entity_for(&id).unwrap();
         assert!(store.world().get::<StaticMeshComponent>(entity).is_none());
     }
+
+    /// Phase B5 (Pulsar-Native#556) spot check: the migration mechanism
+    /// itself is already fully proven generically (`pulsar_world_registry`'s
+    /// own tests) and end-to-end on `StaticMeshComponent` above -- this
+    /// isn't re-proving the mechanism per component (that would just be
+    /// duplicating the same five tests seven more times), it's checking for
+    /// component-specific surprises. `LightComponent` has many fields with
+    /// nested enum sub-props (`IntensityUnits`, `ShadowCacheMode`, ...) --
+    /// worth confirming `Default`-derived JSON round-trips through
+    /// hydration cleanly, not just a single-field component like
+    /// `StaticMeshComponent`.
+    #[test]
+    fn light_component_hydrates_via_its_default_json() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Light"), None);
+        let default_json = serde_json::to_value(pulsar_rendering::LightComponent::default()).unwrap();
+
+        db.add_component(&id, "LightComponent".to_string(), default_json);
+
+        let store = db.store.read();
+        let entity = store.entity_for(&id).unwrap();
+        assert!(store.world().get::<pulsar_rendering::LightComponent>(entity).is_some());
+    }
+
+    /// `PortalComponent` is the trickiest of B5's list -- its
+    /// `sync_component` pairs two components sharing a `portal_id` via
+    /// `PortalLinkCache`, tracked independently of storage. Worth confirming
+    /// two portal-typed objects both hydrate correctly (the pairing logic
+    /// itself is unaffected by storage, but this proves *that* claim rather
+    /// than just asserting it).
+    #[test]
+    fn portal_component_hydrates_on_both_sides_of_a_pair() {
+        let db = SceneDatabase::new();
+        let a = db.add_object(object("PortalA"), None);
+        let b = db.add_object(object("PortalB"), None);
+        let default_json = serde_json::to_value(pulsar_rendering::PortalComponent::default()).unwrap();
+
+        db.add_component(&a, "PortalComponent".to_string(), default_json.clone());
+        db.add_component(&b, "PortalComponent".to_string(), default_json);
+
+        let store = db.store.read();
+        let entity_a = store.entity_for(&a).unwrap();
+        let entity_b = store.entity_for(&b).unwrap();
+        assert!(store.world().get::<pulsar_rendering::PortalComponent>(entity_a).is_some());
+        assert!(store.world().get::<pulsar_rendering::PortalComponent>(entity_b).is_some());
+    }
 }

--- a/crates/subsystems/pulsar_physics/Cargo.toml
+++ b/crates/subsystems/pulsar_physics/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 engine_class_derive = { workspace = true }
 pulsar_reflection = { workspace = true }
 pulsar_scenedb = { workspace = true }
+pulsar_world_registry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/subsystems/pulsar_physics/src/components/physics_component/runtime.rs
+++ b/crates/subsystems/pulsar_physics/src/components/physics_component/runtime.rs
@@ -1,8 +1,13 @@
-use engine_class_derive::register_runtime_behavior;
+use engine_class_derive::{register_runtime_behavior, register_world_component};
 use pulsar_reflection::{ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner};
 
 use super::PhysicsComponent;
 
+// Phase B5 (Pulsar-Native#556). sync_component is a no-op stub today (real
+// physics-engine integration hasn't landed) -- migrating it onto World
+// storage now is a free win: nothing real to port, and it's ready for when
+// that integration does land.
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for PhysicsComponent {
     const CLASS_NAME: &'static str = "PhysicsComponent";

--- a/crates/subsystems/pulsar_physics/src/components/rigidbody_component/runtime.rs
+++ b/crates/subsystems/pulsar_physics/src/components/rigidbody_component/runtime.rs
@@ -1,8 +1,11 @@
-use engine_class_derive::register_runtime_behavior;
+use engine_class_derive::{register_runtime_behavior, register_world_component};
 use pulsar_reflection::{ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner};
 
 use super::RigidbodyComponent;
 
+// Phase B5 (Pulsar-Native#556). Same free-win rationale as PhysicsComponent
+// -- sync_component is a no-op stub today.
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for RigidbodyComponent {
     const CLASS_NAME: &'static str = "RigidbodyComponent";

--- a/crates/subsystems/pulsar_rendering/src/components/foliage_component/runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/foliage_component/runtime.rs
@@ -1,4 +1,4 @@
-use engine_class_derive::register_runtime_behavior;
+use engine_class_derive::{register_runtime_behavior, register_world_component};
 use helio::{
     FoliageInteractor, FoliageLayer, FoliageTypeDescriptor, GpuMaterial, MaterialId, Renderer,
 };
@@ -151,6 +151,8 @@ fn remove_foliage_with_context(
     cache.map.remove(key);
 }
 
+// Phase B5 (Pulsar-Native#556).
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for FoliageComponent {
     const CLASS_NAME: &'static str = "FoliageComponent";

--- a/crates/subsystems/pulsar_rendering/src/components/light_component/runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/light_component/runtime.rs
@@ -1,4 +1,4 @@
-use engine_class_derive::register_runtime_behavior;
+use engine_class_derive::{register_runtime_behavior, register_world_component};
 use helio::{GpuLight, LightType as HelioLightType, Renderer, SceneActor};
 use pulsar_reflection::{
     get_subsystem, scene_id_to_tag, ComponentRuntimeBehavior, ComponentRuntimeContext,
@@ -7,6 +7,8 @@ use pulsar_reflection::{
 
 use super::{LightComponent, LightType};
 
+// Phase B5 (Pulsar-Native#556).
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for LightComponent {
     const CLASS_NAME: &'static str = "LightComponent";

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/runtime.rs
@@ -1,4 +1,4 @@
-use engine_class_derive::register_runtime_behavior;
+use engine_class_derive::{register_runtime_behavior, register_world_component};
 use pulsar_reflection::{
     ComponentRuntimeBehavior, ComponentRuntimeContext, LiveKeySet, RuntimeComponentOwner,
 };
@@ -8,6 +8,8 @@ use super::{
     ComponentError, PLANET_TERRAIN_CLASS_NAME, PlanetTerrainComponent, PlanetTerrainComponentCache,
 };
 
+// Phase B5 (Pulsar-Native#556).
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for PlanetTerrainComponent {
     const CLASS_NAME: &'static str = PLANET_TERRAIN_CLASS_NAME;

--- a/crates/subsystems/pulsar_rendering/src/components/portal_component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/portal_component.rs
@@ -17,7 +17,7 @@
 //! `RuntimeComponentOwner`), so animating, dragging, or otherwise moving the
 //! parent object moves its side of the portal automatically.
 
-use engine_class_derive::{engine_class, register_runtime_behavior};
+use engine_class_derive::{engine_class, register_runtime_behavior, register_world_component};
 use pulsar_reflection::{
     ComponentRuntimeBehavior, ComponentRuntimeContext, LiveKeySet, RuntimeComponentOwner,
     get_subsystem,
@@ -65,6 +65,11 @@ impl Default for PortalComponent {
     }
 }
 
+// Phase B5 (Pulsar-Native#556). Pairing logic (PortalLinkCache) lives
+// inside sync_component's own body, unaffected by whether the component
+// value came from JSON or a hydrated World value -- no special handling
+// needed here for that.
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for PortalComponent {
     const CLASS_NAME: &'static str = PORTAL_CLASS_NAME;

--- a/crates/subsystems/pulsar_rendering/src/components/script_component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/script_component.rs
@@ -1,7 +1,9 @@
 //! Script component — attaches a blueprint actor script to a scene object.
 
 use crate::asset_component::AssetComponentRegistration;
-use engine_class_derive::{engine_class, register_runtime_behavior, register_scene_props_applier};
+use engine_class_derive::{
+    engine_class, register_runtime_behavior, register_scene_props_applier, register_world_component,
+};
 
 pulsar_reflection::inventory::submit! {
     AssetComponentRegistration {
@@ -246,6 +248,8 @@ impl ScenePropsProjector for ScriptComponent {
     }
 }
 
+// Phase B5 (Pulsar-Native#556).
+#[register_world_component]
 #[register_runtime_behavior]
 impl ComponentRuntimeBehavior for ScriptComponent {
     const CLASS_NAME: &'static str = "ScriptComponent";


### PR DESCRIPTION
Implements [Pulsar-Native#556](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/issues/556). Stacked on #564 (B4).

Applies B4's proven `#[register_world_component]` mechanism to every remaining component with a real `ComponentRuntimeBehavior` impl: `LightComponent`, `PortalComponent`, `PlanetTerrainComponent`, `FoliageComponent`, `ScriptComponent`, `PhysicsComponent`, `RigidbodyComponent` (`pulsar_physics`).

Genuinely mechanical — every one of these already derives `Deserialize` (required by the `#[register_runtime_behavior]` they all already carry), so the new attribute stacks on cleanly with no per-component special-casing.

**Not migrated, confirmed not overlooked**: `LODComponent`/`MaterialOverrideComponent` have no `ComponentRuntimeBehavior` impl at all (props-only) — structurally can't use this mechanism, matching #556's own inventory.

## Verification

Full regression green across `engine_backend`, `pulsar_rendering`, `pulsar_physics`, `pulsar_world_registry`, `ui_level_editor` (34 tests, up from 32). Two new spot-check tests (`LightComponent` for a many-field/nested-enum component, `PortalComponent` for the paired-component case) rather than one per component — the mechanism itself is already proven generically and end-to-end in B4; re-testing it 7 more times wouldn't catch anything new. `pulsar_engine` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
