### PR TITLE
B6 (partial): delete vestigial SceneMetadataDb snapshot code

### DIFF
--- a/crates/core/engine_backend/src/lib.rs
+++ b/crates/core/engine_backend/src/lib.rs
@@ -32,7 +32,7 @@ pub use pulsar_reflection::*;
 // Re-export scene types used by UI crates
 pub use scene::{
     ComponentInstance, EditorObjectId, HelioActorHandle, MetadataObjectType, SceneMetadataDb,
-    SceneObjectMetadata, SceneSnapshot,
+    SceneObjectMetadata,
 };
 
 /// Global instance handle, set once during engine init.

--- a/crates/core/engine_backend/src/scene/metadata_db.rs
+++ b/crates/core/engine_backend/src/scene/metadata_db.rs
@@ -437,51 +437,6 @@ impl Default for SceneMetadataDb {
     }
 }
 
-/// Serializable scene snapshot for save/load
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SceneSnapshot {
-    /// All objects in depth-first order
-    pub objects: Vec<SceneObjectMetadata>,
-
-    /// Component data per object
-    pub components: Vec<(EditorObjectId, Vec<super::metadata::ComponentInstance>)>,
-}
-
-impl SceneMetadataDb {
-    /// Create a snapshot for serialization
-    pub fn create_snapshot(&self) -> SceneSnapshot {
-        let objects = self.get_all_objects_dfs();
-
-        let components: Vec<_> = objects
-            .iter()
-            .map(|obj| (obj.editor_id.clone(), self.get_components(&obj.editor_id)))
-            .filter(|(_, comps)| !comps.is_empty())
-            .collect();
-
-        SceneSnapshot {
-            objects,
-            components,
-        }
-    }
-
-    /// Load from a snapshot
-    pub fn load_snapshot(&self, snapshot: SceneSnapshot) {
-        self.clear();
-
-        // Load objects (they're already in depth-first order, so parents before children)
-        for metadata in snapshot.objects {
-            self.add_object(metadata.clone(), metadata.parent.clone());
-        }
-
-        // Load components
-        for (object_id, components) in snapshot.components {
-            for component in components {
-                self.add_component_instance(&object_id, component);
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/engine_backend/src/scene/mod.rs
+++ b/crates/core/engine_backend/src/scene/mod.rs
@@ -37,7 +37,7 @@ pub use metadata::{
     LightType as MetadataLightType, MeshType as MetadataMeshType, ObjectType as MetadataObjectType,
     SceneObjectMetadata,
 };
-pub use metadata_db::{SceneMetadataDb, SceneSnapshot};
+pub use metadata_db::SceneMetadataDb;
 pub use world_store::{
     Name, ObjectSnapshot, Parent, RenderProps, StableId, Transform, Visibility, WorldSceneStore,
     WorldSceneStoreError,


### PR DESCRIPTION
Implements the confirmed-safe half of [Pulsar-Native#557](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/issues/557). Stacked on #565 (B5).

Re-verified the "zero call sites outside its own tests" finding still holds, then deleted `SceneSnapshot`/`SceneMetadataDb::create_snapshot`/`::load_snapshot` and their two re-exports. `SceneObjectMetadata` stays — it's `SceneMetadataDb`'s actual live CRUD type, unrelated to the vestigial snapshot feature.

## The other half of #557 — not attempted here, full writeup on the issue

Read `pulsar_scene::loader.rs` in full before touching it: the game runtime's `SceneLoader` is entirely `pulsar_scenedb::World`-free by design — a one-shot loader that dispatches straight from JSON into the Helio renderer, never spawning a `World` entity. Also confirmed real (not just conventional) divergence between `SceneObject` (game format) and `SceneObjectData` (editor format) — different `ObjectType`/`LightType` enum coverage, v1-flat-transform fallback fields the editor format doesn't model, and runtime-only projected-prop accessors that don't belong on the editor type.

Forcing a structural merge here risks silently narrowing the editor's save format or changing game-load behavior for existing v1 files. This needs a real design decision, not a mechanical merge — full details in the commit message and posted on #557.

## Verification

`engine_backend`: 52 tests green. `pulsar_engine` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
