### PR TITLE
Phase D: ReflectionCaptureComponent -- first new primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9115,6 +9115,7 @@ dependencies = [
  "helio-asset-compat",
  "helio-pass-planetary-voxel",
  "helio-planet-voxel-core",
+ "libhelio",
  "plugin_editor_api",
  "pollster 0.4.0",
  "pulsar_events",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,12 @@ helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio
 helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
 helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
 helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
+# `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
+# (or other libhelio-only types Phase D's new components need) -- rather
+# than editing the Helio submodule itself (already in a dirty, unrelated
+# state locally; a cross-repo change for a one-line re-export isn't worth
+# the coordination), depend on libhelio directly at the same pinned rev.
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -1317,4 +1317,26 @@ mod world_component_hydration_tests {
         assert!(store.world().get::<pulsar_rendering::PortalComponent>(entity_a).is_some());
         assert!(store.world().get::<pulsar_rendering::PortalComponent>(entity_b).is_some());
     }
+
+    /// Phase D (Pulsar-Native#558): `ReflectionCaptureComponent` is the
+    /// first newly-authored (not migrated) component to go through this
+    /// mechanism -- same spot-check shape as B5's, confirming the
+    /// already-proven mechanism holds for brand-new components too, not
+    /// just migrated ones.
+    #[test]
+    fn reflection_capture_component_hydrates_via_its_default_json() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Probe"), None);
+        let default_json =
+            serde_json::to_value(pulsar_rendering::ReflectionCaptureComponent::default()).unwrap();
+
+        db.add_component(&id, "ReflectionCaptureComponent".to_string(), default_json);
+
+        let store = db.store.read();
+        let entity = store.entity_for(&id).unwrap();
+        assert!(store
+            .world()
+            .get::<pulsar_rendering::ReflectionCaptureComponent>(entity)
+            .is_some());
+    }
 }

--- a/crates/subsystems/pulsar_rendering/Cargo.toml
+++ b/crates/subsystems/pulsar_rendering/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 glam = { workspace = true, features = ["serde"] }
 helio.workspace = true
+libhelio.workspace = true
 helio-asset-compat = { workspace = true }
 helio-planet-voxel-core = { workspace = true }
 helio-pass-planetary-voxel = { workspace = true }

--- a/crates/subsystems/pulsar_rendering/src/components/mod.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/mod.rs
@@ -4,6 +4,7 @@ mod lod_component;
 mod material_override;
 mod planet_terrain_component;
 mod portal_component;
+mod reflection_capture_component;
 mod script_component;
 mod static_mesh_component;
 
@@ -13,5 +14,6 @@ pub use lod_component::*;
 pub use material_override::*;
 pub use planet_terrain_component::*;
 pub use portal_component::*;
+pub use reflection_capture_component::*;
 pub use script_component::*;
 pub use static_mesh_component::*;

--- a/crates/subsystems/pulsar_rendering/src/components/reflection_capture_component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/reflection_capture_component.rs
@@ -1,0 +1,265 @@
+//! Reflection capture component (Phase D, Pulsar-Native#558) — the first of
+//! the "no purpose-built component exists yet" primitives from Helio's own
+//! inventory. Places a parallax-corrected reflection probe influence volume
+//! in the scene.
+//!
+//! Helio already has full native support for this (`Scene::
+//! insert_reflection_capture`/`update_reflection_capture`/
+//! `remove_reflection_capture`, `ReflectionCaptureDescriptor`) — the gap
+//! this closes is purely the author-facing `#[engine_class]` wrapper, same
+//! as every component migrated in Phase B4/B5.
+//!
+//! `libhelio::ReflectionCaptureShape`/`ReflectionCaptureMobility` aren't
+//! re-exported from `helio`'s own crate root and aren't reflection-friendly
+//! (no `Serialize`/`Deserialize`) even if they were, so this module defines
+//! its own mirrored enums rather than reusing them directly or editing the
+//! Helio submodule (already in an unrelated dirty state locally; not worth
+//! a cross-repo change for a two-variant enum).
+//!
+//! Unlike `StaticMeshComponent`/`LightComponent`/`PortalComponent`, this
+//! goes through `Scene::insert_reflection_capture`/etc. directly rather than
+//! `SceneActor::reflection_capture(..)` + `Scene::insert_actor`: those
+//! components need the `SceneActor`/tag machinery specifically for
+//! click-to-select picking, which reflection captures don't have wired up
+//! yet (deferred, along with gizmo interaction, for a follow-up — this pass
+//! is the data-sync mechanism, not full editor interaction). The direct
+//! `Scene` methods hand back the typed `ReflectionCaptureId` this
+//! component's own cache needs anyway.
+
+use engine_class_derive::{engine_class, register_runtime_behavior, register_world_component};
+use glam::{EulerRot, Mat4, Quat, Vec3};
+use helio::{ReflectionCaptureDescriptor, Renderer};
+use libhelio::{
+    ReflectionCaptureMobility as HelioReflectionCaptureMobility,
+    ReflectionCaptureShape as HelioReflectionCaptureShape,
+};
+use pulsar_reflection::{
+    get_subsystem, ComponentRuntimeBehavior, ComponentRuntimeContext, Reflectable,
+    RuntimeComponentOwner,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::subsystems::ReflectionCaptureCache;
+
+pub const REFLECTION_CAPTURE_CLASS_NAME: &str = "ReflectionCaptureComponent";
+
+/// Influence-volume shape. Mirrors `libhelio::ReflectionCaptureShape`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Reflectable)]
+pub enum ReflectionCaptureShape {
+    /// Radial influence, faded over the outer 10% of `influence_radius`.
+    Sphere,
+    /// Oriented box influence (takes its rotation from the owning object),
+    /// faded over `transition_distance` from each face.
+    Box,
+}
+
+impl Default for ReflectionCaptureShape {
+    fn default() -> Self {
+        Self::Sphere
+    }
+}
+
+/// How the capture's cubemap pixels are produced. Mirrors
+/// `libhelio::ReflectionCaptureMobility`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Reflectable)]
+pub enum ReflectionCaptureMobility {
+    /// Pre-filtered offline by the probe baker. The only mode that
+    /// contributes anything today.
+    Static,
+    /// Re-rendered at runtime rather than baked. **Not implemented in Helio
+    /// yet** — a `Dynamic` capture is inert (never assigned a cubemap
+    /// layer), see `libhelio::ReflectionCaptureMobility::Dynamic`'s own doc.
+    /// Exposed now for forward compatibility, not because it does anything.
+    Dynamic,
+}
+
+impl Default for ReflectionCaptureMobility {
+    fn default() -> Self {
+        Self::Static
+    }
+}
+
+/// Places a reflection probe influence volume in the scene.
+#[engine_class(category = "Rendering", clone, debug, serialize, deserialize)]
+pub struct ReflectionCaptureComponent {
+    #[property]
+    pub enabled: bool,
+    #[property]
+    pub shape: ReflectionCaptureShape,
+    #[property]
+    pub mobility: ReflectionCaptureMobility,
+    /// Sphere influence radius, in world units. Ignored for `Box` shape.
+    #[property(min = 0.1, max = 10000.0, step = 0.5)]
+    pub influence_radius: f32,
+    /// Box half-extents, in capture-local space. Ignored for `Sphere` shape.
+    #[property]
+    pub extents: [f32; 3],
+    /// Distance over which a box capture fades out at its faces. Sphere
+    /// captures always fade over the outer 10% of `influence_radius`
+    /// instead, regardless of this value.
+    #[property(min = 0.0, max = 100.0, step = 0.1)]
+    pub transition_distance: f32,
+    /// Linear multiplier on the sampled radiance.
+    #[property(min = 0.0, max = 10.0, step = 0.05)]
+    pub brightness: f32,
+}
+
+impl Default for ReflectionCaptureComponent {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            shape: ReflectionCaptureShape::Sphere,
+            mobility: ReflectionCaptureMobility::Static,
+            influence_radius: 10.0,
+            extents: [5.0; 3],
+            transition_distance: 1.0,
+            brightness: 1.0,
+        }
+    }
+}
+
+#[register_world_component]
+#[register_runtime_behavior]
+impl ComponentRuntimeBehavior for ReflectionCaptureComponent {
+    const CLASS_NAME: &'static str = REFLECTION_CAPTURE_CLASS_NAME;
+
+    fn sync_component(
+        owner: &RuntimeComponentOwner,
+        _component_index: usize,
+        component: &Self,
+        context: &mut dyn ComponentRuntimeContext,
+    ) {
+        // Phase 1: consult the cache and release its borrow immediately --
+        // a `ComponentRuntimeContext` can't hand out two simultaneous
+        // mutable subsystem borrows (same constraint `PortalComponent`
+        // documents for the same reason).
+        let cached_id = get_subsystem!(context, ReflectionCaptureCache).get(owner.scene_object_id);
+
+        if !component.enabled {
+            if let Some(id) = cached_id {
+                let removed = get_subsystem!(context, Renderer)
+                    .scene_mut()
+                    .remove_reflection_capture(id);
+                if removed {
+                    get_subsystem!(context, ReflectionCaptureCache).remove(owner.scene_object_id);
+                }
+            }
+            return;
+        }
+
+        // Box captures take their rotation from `transform`; sphere captures
+        // use only the translation (`ReflectionCaptureDescriptor`'s own
+        // doc). Scale is deliberately not applied here -- `extents`/
+        // `influence_radius` are this component's own authored size fields,
+        // independent of the owning object's scale, matching how
+        // `PortalComponent`'s width/height aren't scaled by owner.scale
+        // either.
+        let rotation = Quat::from_euler(
+            EulerRot::YXZ,
+            owner.rotation[1].to_radians(),
+            owner.rotation[0].to_radians(),
+            owner.rotation[2].to_radians(),
+        );
+        let transform = Mat4::from_rotation_translation(rotation, Vec3::from_array(owner.position));
+
+        let descriptor = ReflectionCaptureDescriptor {
+            shape: match component.shape {
+                ReflectionCaptureShape::Sphere => HelioReflectionCaptureShape::Sphere,
+                ReflectionCaptureShape::Box => HelioReflectionCaptureShape::Box,
+            },
+            mobility: match component.mobility {
+                ReflectionCaptureMobility::Static => HelioReflectionCaptureMobility::Static,
+                ReflectionCaptureMobility::Dynamic => HelioReflectionCaptureMobility::Dynamic,
+            },
+            transform,
+            influence_radius: component.influence_radius,
+            extents: component.extents,
+            transition_distance: component.transition_distance,
+            brightness: component.brightness,
+        };
+
+        match cached_id {
+            Some(id) => {
+                let _ = get_subsystem!(context, Renderer)
+                    .scene_mut()
+                    .update_reflection_capture(id, &descriptor);
+            }
+            None => {
+                let inserted = get_subsystem!(context, Renderer)
+                    .scene_mut()
+                    .insert_reflection_capture(descriptor);
+                if let Ok(id) = inserted {
+                    get_subsystem!(context, ReflectionCaptureCache)
+                        .insert(owner.scene_object_id.to_string(), id);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine_subsystems::{Subsystem, SubsystemContext};
+    use pulsar_reflection::{apply_runtime_behavior_for_class, Subsystems};
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    struct TestRuntimeContext {
+        project_root: PathBuf,
+        subsystems: Subsystems,
+        errors: Vec<String>,
+    }
+
+    impl ComponentRuntimeContext for TestRuntimeContext {
+        fn subsystems_mut(&mut self) -> &mut Subsystems {
+            &mut self.subsystems
+        }
+        fn project_root(&self) -> &Path {
+            &self.project_root
+        }
+        fn report_error(&mut self, message: String) {
+            self.errors.push(message);
+        }
+    }
+
+    fn owner<'a>(props: &'a HashMap<String, serde_json::Value>) -> RuntimeComponentOwner<'a> {
+        RuntimeComponentOwner {
+            scene_object_id: "probe",
+            position: [1.0, 2.0, 3.0],
+            rotation: [0.0; 3],
+            scale: [1.0; 3],
+            props,
+        }
+    }
+
+    #[test]
+    fn runtime_behavior_has_the_reflected_component_name() {
+        assert_eq!(
+            <ReflectionCaptureComponent as ComponentRuntimeBehavior>::CLASS_NAME,
+            REFLECTION_CAPTURE_CLASS_NAME
+        );
+    }
+
+    #[test]
+    fn disabling_a_never_inserted_capture_is_a_quiet_no_op() {
+        let mut subsystems = Subsystems::new();
+        subsystems.register(ReflectionCaptureCache::new());
+        let mut context = TestRuntimeContext {
+            project_root: PathBuf::from("."),
+            subsystems,
+            errors: Vec::new(),
+        };
+        let props = HashMap::new();
+        let disabled = ReflectionCaptureComponent { enabled: false, ..Default::default() };
+
+        assert!(apply_runtime_behavior_for_class(
+            REFLECTION_CAPTURE_CLASS_NAME,
+            &owner(&props),
+            0,
+            &serde_json::to_value(disabled).unwrap(),
+            &mut context,
+        ));
+        assert!(context.errors.is_empty());
+    }
+}

--- a/crates/subsystems/pulsar_rendering/src/subsystems.rs
+++ b/crates/subsystems/pulsar_rendering/src/subsystems.rs
@@ -143,6 +143,37 @@ impl LightCache {
     }
 }
 
+/// Same shape as [`LightCache`], for reflection captures (Phase D,
+/// Pulsar-Native#558). Unlike objects/lights, `helio::Scene` has no
+/// `reflection_capture_by_tag` lookup at all -- there's no tag-based
+/// mechanism to ask Helio "do I already have one of these for this scene
+/// object", so every `ReflectionCaptureComponent` sync pass needs this
+/// editor-side cache to know whether to `insert_reflection_capture` or
+/// `update_reflection_capture`.
+pub struct ReflectionCaptureCache {
+    pub map: HashMap<String, helio::ReflectionCaptureId>,
+}
+
+impl ReflectionCaptureCache {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, scene_id: &str) -> Option<helio::ReflectionCaptureId> {
+        self.map.get(scene_id).copied()
+    }
+
+    pub fn insert(&mut self, scene_id: String, id: helio::ReflectionCaptureId) {
+        self.map.insert(scene_id, id);
+    }
+
+    pub fn remove(&mut self, scene_id: &str) -> Option<helio::ReflectionCaptureId> {
+        self.map.remove(scene_id)
+    }
+}
+
 /// One side of a to-be-paired portal — this object's current pose and
 /// opening size, recorded by `PortalComponent::sync_component` every sync
 /// pass under the `portal_id` the level designer chose to link two

--- a/crates/subsystems/pulsar_scene/src/loader.rs
+++ b/crates/subsystems/pulsar_scene/src/loader.rs
@@ -47,6 +47,7 @@ pub use pulsar_rendering::FoliageComponent as _ForceLink_FoliageComponent;
 pub use pulsar_rendering::LightComponent as _ForceLink_LightComponent;
 pub use pulsar_rendering::PlanetTerrainComponent as _ForceLink_PlanetTerrainComponent;
 pub use pulsar_rendering::PortalComponent as _ForceLink_PortalComponent;
+pub use pulsar_rendering::ReflectionCaptureComponent as _ForceLink_ReflectionCaptureComponent;
 pub use pulsar_rendering::ScriptComponent as _ForceLink_ScriptComponent;
 pub use pulsar_rendering::StaticMeshComponent as _ForceLink_StaticMeshComponent;
 


### PR DESCRIPTION
First component of [Pulsar-Native#558](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/issues/558)'s "no purpose-built component exists yet" list.

## Why reflection captures first

Checked Helio's `SceneActor` API for all 7 primitives before picking one. Decals — the most obviously "simple" looking — turned out to need real texture loading (`albedo_texture_index`, a bindless GPU slot) that **doesn't exist anywhere in `pulsar_rendering` today** (grepped, zero hits; even `StaticMeshComponent`'s material hardcodes `NO_TEXTURE` placeholders). Reflection captures, water volumes, and post-process volumes are all purely numeric/procedural — tractable now. Decals are deferred until texture-loading infrastructure exists (a separate prerequisite, not something to bolt on as a side effect of one component).

## What's new

- `libhelio` added as a direct workspace dependency (same pinned rev as `helio`) — needed for `ReflectionCaptureShape`/`ReflectionCaptureMobility`, which aren't re-exported from `helio`'s own crate root. Didn't touch the Helio submodule itself (already dirty locally from unrelated prior work).
- `ReflectionCaptureComponent` — full field set, `#[register_runtime_behavior]` + `#[register_world_component]` like every B4/B5 component. Goes through `Scene::insert_reflection_capture` directly rather than the `SceneActor`/`insert_actor` path, since picking/gizmo integration for this new volume type is deliberately deferred.
- `ReflectionCaptureCache` (same shape as the existing `LightCache`) — `Scene` has no `reflection_capture_by_tag` lookup, so this is what lets repeat syncs update in place.
- Added to `pulsar_scene::loader.rs`'s force-link list (the existing linker-safety mechanism every real component needs).

## Verification

3 new tests (2 in the component, 1 end-to-end World-hydration spot check in `scene_database.rs`). Full regression green: `pulsar_rendering` (21), `pulsar_scene` (1), `ui_level_editor` (35). `pulsar_engine` builds clean.

Not done: manual editor verification (place a capture, confirm it affects reflections) and click-to-select/gizmo interaction (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
