### PR TITLE
Replace planet authority with a volumetric SDF

### DIFF
--- a/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
+++ b/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
@@ -1,14 +1,30 @@
 use engine_fs::virtual_fs;
 use engine_subsystems::{Subsystem, SubsystemContext};
 use pulsar_terrain::{
-    CellWord, ContentHash, EditMode, EditOp, EditShape, FixedSphereGenerator, NodeState, PageKey,
-    PlanetDefinition, PlanetId, PlanetPosition, PlanetView, SparseBrickTree, TerrainCore,
+    CellWord, ContentHash, EditMode, EditOp, EditShape, NodeState, PageKey, PlanetDefinition,
+    PlanetId, PlanetPosition, PlanetSdfConfig, PlanetView, SparseBrickTree, TerrainCore,
     TerrainIncrementalResidencySession, TerrainPersistenceEvent, TerrainPersistenceHandle,
     TerrainPlanningConfig, TerrainRefinementConfig, TerrainRefinementFrontier,
     TerrainRenderDeltaConfig, TerrainRenderDeltaPublisher, TerrainRuntimeConfig, TerrainStore,
     TerrainStreamingConfig, TerrainStreamingPlanner, TerrainSubsystem,
 };
 use std::time::{Duration, Instant};
+
+const SMOOTH_CELL_SIZE_MM: u32 = 1_000;
+const EARTH_RADIUS_CELLS: u64 = 6_371_000;
+
+fn benchmark_planet(planet_id: PlanetId) -> PlanetDefinition {
+    PlanetDefinition {
+        planet_id,
+        center_cell: [0; 3],
+        radius_cells: EARTH_RADIUS_CELLS,
+        material: 1,
+        lod0_cell_size_mm: SMOOTH_CELL_SIZE_MM,
+        sdf: PlanetSdfConfig::earthlike(0x5eed, SMOOTH_CELL_SIZE_MM).unwrap(),
+        root_lod: 22,
+        max_resident_pages: 2_048,
+    }
+}
 
 fn wait_for_persistence_event(handle: &TerrainPersistenceHandle) -> TerrainPersistenceEvent {
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -46,16 +62,9 @@ fn main() {
     std::hint::black_box(&dense);
     let dense_time = dense_started.elapsed();
 
-    let mut core = TerrainCore::new(
-        PlanetId([1; 16]),
-        24,
-        FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 63_710_000,
-            material: 1,
-        },
-    )
-    .unwrap();
+    let core_planet = benchmark_planet(PlanetId([1; 16]));
+    let mut core =
+        TerrainCore::new(core_planet.planet_id, 24, core_planet.generator().unwrap()).unwrap();
     core.append_edit(EditOp {
         sequence: 1,
         stable_id: [1; 16],
@@ -71,14 +80,11 @@ fn main() {
     let compacted = core.compact_page(PageKey::new(0, [0; 3])).unwrap();
     let edit_time = edit_started.elapsed();
 
+    let coarse_planet = benchmark_planet(PlanetId([3; 16]));
     let mut coarse_core = TerrainCore::new(
-        PlanetId([3; 16]),
+        coarse_planet.planet_id,
         24,
-        FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 63_710_000,
-            material: 1,
-        },
+        coarse_planet.generator().unwrap(),
     )
     .unwrap();
     coarse_core
@@ -99,14 +105,11 @@ fn main() {
     let coarse_work = coarse_core.work_counters();
 
     const DELETE_EDIT_PREFIX: u64 = 10_000;
+    let delete_planet = benchmark_planet(PlanetId([4; 16]));
     let mut delete_core = TerrainCore::new(
-        PlanetId([4; 16]),
+        delete_planet.planet_id,
         24,
-        FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 63_710_000,
-            material: 1,
-        },
+        delete_planet.generator().unwrap(),
     )
     .unwrap();
     for sequence in 1..=DELETE_EDIT_PREFIX {
@@ -156,16 +159,9 @@ fn main() {
     let memory = core.memory_counters();
     let work = core.work_counters();
 
-    let planet = PlanetDefinition {
-        planet_id: PlanetId([2; 16]),
-        center_cell: [0; 3],
-        radius_cells: 63_710_000,
-        material: 1,
-        root_lod: 22,
-        max_resident_pages: 2_048,
-    };
+    let planet = benchmark_planet(PlanetId([2; 16]));
     let view = PlanetView::new(
-        PlanetPosition::from_lod0_cell([103_710_000, 0, 0]),
+        PlanetPosition::from_lod0_cell([10_371_000, 0, 0], planet.lod0_cell_size_mm).unwrap(),
         [-1.0, 0.0, 0.0],
         [0.0, 1.0, 0.0],
         60_f64.to_radians(),
@@ -185,7 +181,7 @@ fn main() {
     let mut latest_plan = None;
     for _ in 0..20 {
         let started = Instant::now();
-        let plan = planner.plan_fixed_sphere(&planet, view).unwrap();
+        let plan = planner.plan_planet(&planet, view).unwrap();
         plan_times.push(started.elapsed());
         latest_plan = Some(plan);
     }
@@ -195,11 +191,7 @@ fn main() {
     let planning_core = TerrainCore::new(
         planet.planet_id,
         planet.root_lod,
-        FixedSphereGenerator {
-            center_cell: planet.center_cell,
-            radius_cells: planet.radius_cells,
-            material: planet.material,
-        },
+        planet.generator().unwrap(),
     )
     .unwrap();
     let mut authoritative_plan_times = Vec::with_capacity(20);
@@ -289,7 +281,11 @@ fn main() {
     let mut active_planning_submit_times = Vec::with_capacity(1_000);
     for tick in 1..=1_000_i64 {
         let moving_view = PlanetView::new(
-            PlanetPosition::from_lod0_cell([103_710_000 + tick * 10, 0, 0]),
+            PlanetPosition::from_lod0_cell(
+                [10_371_000 + tick * 10, 0, 0],
+                planet.lod0_cell_size_mm,
+            )
+            .unwrap(),
             [-1.0, 0.0, 0.0],
             [0.0, 1.0, 0.0],
             60_f64.to_radians(),
@@ -427,7 +423,11 @@ fn main() {
         ..planet.clone()
     };
     let ground_view = PlanetView::new(
-        PlanetPosition::from_lod0_cell([63_710_000, 0, 0]),
+        PlanetPosition::from_lod0_cell(
+            [EARTH_RADIUS_CELLS as i64, 0, 0],
+            ground_planet.lod0_cell_size_mm,
+        )
+        .unwrap(),
         [-1.0, 0.0, 0.0],
         [0.0, 1.0, 0.0],
         60_f64.to_radians(),
@@ -443,7 +443,7 @@ fn main() {
     for _ in 0..10 {
         let started = Instant::now();
         let plan = ground_planner
-            .plan_fixed_sphere(&ground_planet, ground_view)
+            .plan_planet(&ground_planet, ground_view)
             .unwrap();
         ground_times.push(started.elapsed());
         latest_ground_plan = Some(plan);

--- a/crates/subsystems/pulsar_terrain/src/controller.rs
+++ b/crates/subsystems/pulsar_terrain/src/controller.rs
@@ -382,6 +382,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 200,
             material: 3,
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 6,
             max_resident_pages: 256,
         };
@@ -455,7 +457,7 @@ mod tests {
         )
         .unwrap();
         let view = PlanetView::new(
-            PlanetPosition::from_lod0_cell([2_500, 0, 0]),
+            PlanetPosition::from_lod0_cell([2_500, 0, 0], planet.lod0_cell_size_mm).unwrap(),
             [-1.0, 0.0, 0.0],
             [0.0, 1.0, 0.0],
             60_f64.to_radians(),

--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -946,15 +946,11 @@ pub enum TerrainCoreError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{EditMode, EditShape, FixedSphereGenerator};
+    use crate::{EditMode, EditShape, PlanetSdfGenerator};
 
     #[test]
     fn compaction_publishes_a_hashed_page_and_snapshot() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([1; 16]), 12, generator).unwrap();
         core.append_edit(EditOp {
             sequence: 1,
@@ -1010,11 +1006,7 @@ mod tests {
 
     #[test]
     fn uniform_compaction_and_high_level_override_remain_sparse() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([2; 16]), 24, generator).unwrap();
         let far_page = PageKey::new(0, [1_000_000, 0, 0]);
         core.compact_page(far_page).unwrap();
@@ -1030,11 +1022,7 @@ mod tests {
 
     #[test]
     fn page_compaction_replays_only_spatially_attached_edit_candidates() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([3; 16]), 24, generator).unwrap();
         for sequence in 1..=64_u64 {
             let page = 1_000 + sequence as i64;
@@ -1070,11 +1058,7 @@ mod tests {
 
     #[test]
     fn stale_off_thread_page_build_cannot_replace_newer_terrain() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([4; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [0; 3]);
         core.append_edit(EditOp {
@@ -1117,11 +1101,7 @@ mod tests {
 
     #[test]
     fn unrelated_mutation_does_not_stale_an_off_thread_page_build() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([16; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [0; 3]);
         core.append_edit(EditOp {
@@ -1162,11 +1142,7 @@ mod tests {
 
     #[test]
     fn unrelated_mutation_does_not_rebuild_a_resident_page() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([17; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [0; 3]);
         core.append_edit(EditOp {
@@ -1201,11 +1177,7 @@ mod tests {
 
     #[test]
     fn duplicate_off_thread_page_build_is_idempotent() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([5; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [0; 3]);
         core.append_edit(EditOp {
@@ -1243,11 +1215,7 @@ mod tests {
 
     #[test]
     fn evicted_dense_page_rehydrates_to_the_authoritative_hash() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([6; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [0; 3]);
         core.append_edit(EditOp {
@@ -1278,11 +1246,7 @@ mod tests {
 
     #[test]
     fn evicted_page_full_replay_includes_edits_added_while_absent() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([7; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [0; 3]);
         core.compact_page(key).unwrap();
@@ -1307,11 +1271,7 @@ mod tests {
 
     #[test]
     fn coarse_compaction_replays_edits_attached_to_fine_descendants() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 10_000,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 10_000, 3);
         let mut core = TerrainCore::new(PlanetId([9; 16]), 12, generator).unwrap();
         core.append_edit(EditOp {
             sequence: 1,
@@ -1335,11 +1295,7 @@ mod tests {
 
     #[test]
     fn root_delete_is_authoritative_across_eviction_and_later_union() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 10_000,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 10_000, 3);
         let mut core = TerrainCore::new(PlanetId([10; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [-1, 0, 0]);
         core.append_edit(EditOp {
@@ -1389,11 +1345,7 @@ mod tests {
 
     #[test]
     fn fine_descendant_edit_changes_coarse_summary_without_materializing_pages() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([31; 16]), 12, generator).unwrap();
         let coarse = PageKey::new(4, [2, 0, 0]);
         let before = core.node_summary(coarse).unwrap();
@@ -1424,11 +1376,7 @@ mod tests {
 
     #[test]
     fn summaries_survive_compaction_eviction_and_snapshot_rehydration() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 1_000,
-            material: 5,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 1_000, 5);
         let key = PageKey::new(0, [31, 0, 0]);
         let mut core = TerrainCore::new(PlanetId([32; 16]), 12, generator).unwrap();
         core.append_edit(EditOp {
@@ -1460,11 +1408,7 @@ mod tests {
 
     #[test]
     fn root_delete_replaces_the_authoritative_summary_in_constant_work() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 10_000,
-            material: 5,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 10_000, 5);
         let mut core = TerrainCore::new(PlanetId([33; 16]), 24, generator).unwrap();
         core.compact_page(PageKey::new(0, [0; 3])).unwrap();
         assert!(core.hierarchy().node_count() > 1);
@@ -1480,11 +1424,7 @@ mod tests {
 
     #[test]
     fn procedural_root_reset_discards_older_materialized_edits() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([18; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [1_500, 0, 0]);
         core.append_edit(EditOp {
@@ -1515,11 +1455,7 @@ mod tests {
 
     #[test]
     fn snapshot_restore_rehydrates_deleted_root_to_identical_hash() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 10_000,
-            material: 5,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 10_000, 5);
         let key = PageKey::new(0, [0; 3]);
         let mut core = TerrainCore::new(PlanetId([11; 16]), 12, generator).unwrap();
         core.compact_page(key).unwrap();
@@ -1543,11 +1479,7 @@ mod tests {
 
     #[test]
     fn planning_snapshot_rebuilds_authoritative_summaries_without_page_caches() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 1_000,
-            material: 4,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 1_000, 4);
         let mut core = TerrainCore::new(PlanetId([31; 16]), 12, generator).unwrap();
         core.append_edit(EditOp {
             sequence: 1,
@@ -1584,11 +1516,7 @@ mod tests {
 
     #[test]
     fn snapshot_rejects_hierarchy_summary_from_the_future() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 5,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 5);
         let snapshot = TerrainSnapshot {
             planet_id: PlanetId([34; 16]),
             generator_hash: generator.hash(),
@@ -1613,11 +1541,7 @@ mod tests {
 
     #[test]
     fn signed_region_override_applies_only_inside_aligned_cube() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 10_000,
-            material: 6,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 10_000, 6);
         let mut core = TerrainCore::new(PlanetId([12; 16]), 12, generator).unwrap();
         let region = PageKey::new(2, [-1, -1, -1]);
         core.set_region(region, NodeState::Air).unwrap();
@@ -1646,11 +1570,7 @@ mod tests {
 
     #[test]
     fn override_stale_rejects_pre_delete_worker_result() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([13; 16]), 12, generator).unwrap();
         let key = PageKey::new(0, [0; 3]);
         let result = match core.prepare_page_build(key).unwrap() {
@@ -1667,11 +1587,7 @@ mod tests {
 
     #[test]
     fn edit_and_override_share_one_sequence_and_id_domain() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 3,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 3);
         let mut core = TerrainCore::new(PlanetId([15; 16]), 12, generator).unwrap();
         core.append_override(TerrainOverrideOp {
             sequence: 1,
@@ -1713,11 +1629,7 @@ mod tests {
 
     #[test]
     fn randomized_mutation_replay_matches_snapshot_restore() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 10_000,
-            material: 2,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 10_000, 2);
         let mut core = TerrainCore::new(PlanetId([14; 16]), 12, generator).unwrap();
         let mut random = 0x4d59_5df4_d0f3_3173_u64;
         for sequence in 1..=32_u64 {

--- a/crates/subsystems/pulsar_terrain/src/generator.rs
+++ b/crates/subsystems/pulsar_terrain/src/generator.rs
@@ -1,5 +1,134 @@
 use crate::{CellWord, ContentHash, MaterialId, PageKey, TerrainNodeSummary};
 
+const NOISE_ONE: i64 = 1 << 15;
+
+/// Canonical parameters for the smooth volumetric planet source.
+///
+/// All distances are expressed in the planet's LOD0 cells. The generator uses
+/// integer arithmetic so a seed/configuration has one content identity on
+/// every supported platform.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlanetSdfConfig {
+    pub seed: u64,
+    pub surface_amplitude_cells: u32,
+    pub surface_period_cells: u32,
+    pub surface_octaves: u8,
+    pub overhang_amplitude_cells: u32,
+    pub overhang_period_cells: u32,
+    pub cave_depth_cells: u32,
+    pub cave_period_cells: u32,
+    pub cave_width_cells: u32,
+}
+
+impl PlanetSdfConfig {
+    /// Zero-relief scalar field used only to isolate hierarchy and extraction tests.
+    pub const fn zero_relief_test_fixture() -> Self {
+        Self {
+            seed: 0,
+            surface_amplitude_cells: 0,
+            surface_period_cells: 1,
+            surface_octaves: 0,
+            overhang_amplitude_cells: 0,
+            overhang_period_cells: 1,
+            cave_depth_cells: 0,
+            cave_period_cells: 1,
+            cave_width_cells: 0,
+        }
+    }
+
+    /// Earth-like defaults converted into the planet's explicit sample scale.
+    pub fn earthlike(seed: u64, lod0_cell_size_mm: u32) -> Result<Self, PlanetSdfConfigError> {
+        if lod0_cell_size_mm == 0 {
+            return Err(PlanetSdfConfigError::CellSize);
+        }
+        let cells = |meters: u32| {
+            meters
+                .saturating_mul(1_000)
+                .div_ceil(lod0_cell_size_mm)
+                .max(1)
+        };
+        Ok(Self {
+            seed,
+            surface_amplitude_cells: cells(6_000),
+            surface_period_cells: cells(400_000),
+            surface_octaves: 6,
+            overhang_amplitude_cells: cells(80),
+            overhang_period_cells: cells(160),
+            cave_depth_cells: cells(2_000),
+            cave_period_cells: cells(120),
+            cave_width_cells: cells(12),
+        })
+    }
+
+    pub fn validate(self) -> Result<(), PlanetSdfConfigError> {
+        if self.surface_octaves > 16 {
+            return Err(PlanetSdfConfigError::SurfaceOctaves(self.surface_octaves));
+        }
+        if self.surface_amplitude_cells != 0 && self.surface_period_cells < 2 {
+            return Err(PlanetSdfConfigError::SurfacePeriod(
+                self.surface_period_cells,
+            ));
+        }
+        if self.overhang_amplitude_cells != 0 && self.overhang_period_cells < 2 {
+            return Err(PlanetSdfConfigError::OverhangPeriod(
+                self.overhang_period_cells,
+            ));
+        }
+        if self.cave_width_cells != 0 && (self.cave_depth_cells == 0 || self.cave_period_cells < 2)
+        {
+            return Err(PlanetSdfConfigError::CaveParameters);
+        }
+        Ok(())
+    }
+
+    pub fn maximum_displacement_cells(self) -> u64 {
+        let mut amplitude = u64::from(self.surface_amplitude_cells);
+        let mut total = 0_u64;
+        for _ in 0..self.surface_octaves {
+            total = total.saturating_add(amplitude);
+            amplitude /= 2;
+        }
+        total.saturating_add(u64::from(self.overhang_amplitude_cells))
+    }
+
+    fn unresolved_error_cells(self, lod: u8) -> u64 {
+        let spacing = 1_u64.checked_shl(u32::from(lod)).unwrap_or(u64::MAX);
+        let mut error = spacing;
+        let mut amplitude = u64::from(self.surface_amplitude_cells);
+        let mut period = u64::from(self.surface_period_cells);
+        for _ in 0..self.surface_octaves {
+            if period < spacing.saturating_mul(2) {
+                error = error.saturating_add(amplitude);
+            }
+            amplitude /= 2;
+            period = (period / 2).max(1);
+        }
+        if u64::from(self.overhang_period_cells) < spacing.saturating_mul(2) {
+            error = error.saturating_add(u64::from(self.overhang_amplitude_cells));
+        }
+        if self.cave_width_cells != 0
+            && u64::from(self.cave_period_cells) < spacing.saturating_mul(2)
+        {
+            error = error.saturating_add(u64::from(self.cave_width_cells));
+        }
+        error
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PlanetSdfConfigError {
+    #[error("planet LOD0 cell size must be non-zero")]
+    CellSize,
+    #[error("surface octave count must be <= 16, got {0}")]
+    SurfaceOctaves(u8),
+    #[error("surface period must be >= 2 cells when enabled, got {0}")]
+    SurfacePeriod(u32),
+    #[error("overhang period must be >= 2 cells when enabled, got {0}")]
+    OverhangPeriod(u32),
+    #[error("enabled caves require a nonzero depth and a period of at least 2 cells")]
+    CaveParameters,
+}
+
 /// Deterministic canonical terrain source. Implementations must use integer or
 /// fixed-point math and include every behavior-changing parameter in `hash`.
 pub trait DeterministicGenerator: Send + Sync {
@@ -14,44 +143,148 @@ pub trait DeterministicGenerator: Send + Sync {
     }
 }
 
+/// Pole-free canonical smooth planet SDF.
+///
+/// Relief and caves are evaluated in Cartesian planet space, so there is no
+/// latitude/longitude seam or polar singularity. The scalar is negative in
+/// solid terrain and positive in air.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct FixedSphereGenerator {
+pub struct PlanetSdfGenerator {
     pub center_cell: [i64; 3],
     pub radius_cells: u64,
     pub material: MaterialId,
+    pub config: PlanetSdfConfig,
 }
 
-impl DeterministicGenerator for FixedSphereGenerator {
+impl PlanetSdfGenerator {
+    pub fn new(
+        center_cell: [i64; 3],
+        radius_cells: u64,
+        material: MaterialId,
+        config: PlanetSdfConfig,
+    ) -> Result<Self, PlanetSdfConfigError> {
+        config.validate()?;
+        Ok(Self {
+            center_cell,
+            radius_cells,
+            material,
+            config,
+        })
+    }
+
+    #[doc(hidden)]
+    pub const fn zero_relief_test_fixture(
+        center_cell: [i64; 3],
+        radius_cells: u64,
+        material: MaterialId,
+    ) -> Self {
+        Self {
+            center_cell,
+            radius_cells,
+            material,
+            config: PlanetSdfConfig::zero_relief_test_fixture(),
+        }
+    }
+
+    fn sample_density_i64(self, cell_xyz: [i64; 3]) -> i64 {
+        let local = [
+            cell_xyz[0].saturating_sub(self.center_cell[0]),
+            cell_xyz[1].saturating_sub(self.center_cell[1]),
+            cell_xyz[2].saturating_sub(self.center_cell[2]),
+        ];
+        let distance = integer_sqrt(
+            local
+                .iter()
+                .map(|axis| i128::from(*axis).unsigned_abs().saturating_pow(2))
+                .sum::<u128>(),
+        );
+        let radial = i128::try_from(distance)
+            .unwrap_or(i128::MAX)
+            .saturating_sub(i128::from(self.radius_cells));
+        let relief = fbm_displacement(
+            local,
+            self.config.seed,
+            self.config.surface_amplitude_cells,
+            self.config.surface_period_cells,
+            self.config.surface_octaves,
+        )
+        .saturating_add(scaled_noise(
+            rotate(local, 5),
+            self.config.overhang_period_cells,
+            self.config.overhang_amplitude_cells,
+            self.config.seed ^ 0x6a09_e667_f3bc_c909,
+        ));
+        let surface = radial
+            .saturating_sub(i128::from(relief))
+            .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64;
+
+        if self.config.cave_width_cells == 0 {
+            return surface;
+        }
+        let depth = surface.saturating_neg();
+        let cave_depth = i64::from(self.config.cave_depth_cells);
+        let cave_width = i64::from(self.config.cave_width_cells);
+        if depth < -cave_width || depth > cave_depth.saturating_add(cave_width) {
+            return surface;
+        }
+        let first = value_noise_q15(
+            rotate(local, 1),
+            self.config.cave_period_cells,
+            self.config.seed ^ 0xbb67_ae85_84ca_a73b,
+        )
+        .unsigned_abs() as i64;
+        let second = value_noise_q15(
+            rotate(local, 3),
+            self.config.cave_period_cells,
+            self.config.seed ^ 0x3c6e_f372_fe94_f82b,
+        )
+        .unsigned_abs() as i64;
+        let threshold = NOISE_ONE / 5;
+        let tunnel = threshold
+            .saturating_sub(first.max(second))
+            .saturating_mul(cave_width)
+            / threshold;
+        let band = depth
+            .saturating_add(cave_width)
+            .min(cave_depth.saturating_add(cave_width).saturating_sub(depth));
+        surface.max(tunnel.min(band))
+    }
+}
+
+impl DeterministicGenerator for PlanetSdfGenerator {
     fn hash(&self) -> ContentHash {
-        let mut bytes = Vec::with_capacity(34);
-        bytes.extend_from_slice(b"pulsar.fixed-sphere.v1");
+        let mut bytes = Vec::with_capacity(96);
+        bytes.extend_from_slice(b"pulsar.planet-sdf.v1");
         for axis in self.center_cell {
             bytes.extend_from_slice(&axis.to_le_bytes());
         }
         bytes.extend_from_slice(&self.radius_cells.to_le_bytes());
         bytes.push(self.material);
+        bytes.extend_from_slice(&self.config.seed.to_le_bytes());
+        bytes.extend_from_slice(&self.config.surface_amplitude_cells.to_le_bytes());
+        bytes.extend_from_slice(&self.config.surface_period_cells.to_le_bytes());
+        bytes.push(self.config.surface_octaves);
+        bytes.extend_from_slice(&self.config.overhang_amplitude_cells.to_le_bytes());
+        bytes.extend_from_slice(&self.config.overhang_period_cells.to_le_bytes());
+        bytes.extend_from_slice(&self.config.cave_depth_cells.to_le_bytes());
+        bytes.extend_from_slice(&self.config.cave_period_cells.to_le_bytes());
+        bytes.extend_from_slice(&self.config.cave_width_cells.to_le_bytes());
         ContentHash::of(&bytes)
     }
 
     fn sample_cell(&self, cell_xyz: [i64; 3]) -> CellWord {
-        let delta = [
-            i128::from(cell_xyz[0]) - i128::from(self.center_cell[0]),
-            i128::from(cell_xyz[1]) - i128::from(self.center_cell[1]),
-            i128::from(cell_xyz[2]) - i128::from(self.center_cell[2]),
-        ];
-        let distance_squared = delta
-            .iter()
-            .map(|axis| axis.saturating_mul(*axis) as u128)
-            .sum::<u128>();
-        let distance = integer_sqrt(distance_squared);
-        let signed_distance = (distance as i128 - i128::from(self.radius_cells))
-            .clamp(i128::from(i16::MIN), i128::from(i16::MAX)) as i16;
-        let material = if signed_distance <= 0 {
-            self.material
-        } else {
-            0
-        };
-        CellWord::new(signed_distance, material, 0)
+        let signed_distance = self
+            .sample_density_i64(cell_xyz)
+            .clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16;
+        CellWord::new(
+            signed_distance,
+            if signed_distance <= 0 {
+                self.material
+            } else {
+                0
+            },
+            0,
+        )
     }
 
     fn summarize_region(&self, key: PageKey) -> TerrainNodeSummary {
@@ -70,16 +303,143 @@ impl DeterministicGenerator for FixedSphereGenerator {
         let Some(max_z) = min[2].checked_add(span - 1) else {
             return TerrainNodeSummary::unknown(0);
         };
-        let max = [max_x, max_y, max_z];
-        let (min_density, max_density) =
-            sphere_signed_distance_bounds(self.center_cell, self.radius_cells, min, max);
-        let error = if min_density > 0 || max_density <= 0 {
+        let (base_min, base_max) = sphere_signed_distance_bounds(
+            self.center_cell,
+            self.radius_cells,
+            min,
+            [max_x, max_y, max_z],
+        );
+        let displacement = self
+            .config
+            .maximum_displacement_cells()
+            .min(i32::MAX as u64) as i32;
+        let min_density = base_min.saturating_sub(displacement);
+        let surface_max = base_max.saturating_add(displacement);
+        let caves_possible = self.config.cave_width_cells != 0
+            && min_density <= self.config.cave_width_cells.min(i32::MAX as u32) as i32
+            && surface_max
+                >= -(self
+                    .config
+                    .cave_depth_cells
+                    .saturating_add(self.config.cave_width_cells)
+                    .min(i32::MAX as u32) as i32);
+        let max_density = if caves_possible {
+            surface_max.max(self.config.cave_width_cells.min(i32::MAX as u32) as i32)
+        } else {
+            surface_max
+        };
+        let error = if min_density > 0 || (max_density <= 0 && !caves_possible) {
             0
         } else {
-            1_u64.checked_shl(u32::from(key.lod)).unwrap_or(u64::MAX)
+            self.config.unresolved_error_cells(key.lod)
         };
         TerrainNodeSummary::new(min_density, max_density, error, 0)
-            .expect("sphere bounds are ordered")
+            .expect("planet SDF bounds are ordered")
+    }
+}
+
+fn fbm_displacement(
+    point: [i64; 3],
+    seed: u64,
+    mut amplitude: u32,
+    mut period: u32,
+    octaves: u8,
+) -> i64 {
+    let mut total = 0_i64;
+    for octave in 0..octaves {
+        if amplitude == 0 || period < 2 {
+            break;
+        }
+        total = total.saturating_add(scaled_noise(
+            rotate(point, octave),
+            period,
+            amplitude,
+            seed ^ u64::from(octave).wrapping_mul(0x9e37_79b9_7f4a_7c15),
+        ));
+        amplitude /= 2;
+        period = (period / 2).max(1);
+    }
+    total
+}
+
+fn scaled_noise(point: [i64; 3], period: u32, amplitude: u32, seed: u64) -> i64 {
+    if amplitude == 0 || period < 2 {
+        return 0;
+    }
+    i64::from(value_noise_q15(point, period, seed)).saturating_mul(i64::from(amplitude)) / NOISE_ONE
+}
+
+fn value_noise_q15(point: [i64; 3], period: u32, seed: u64) -> i32 {
+    let period = i64::from(period.max(2));
+    let lattice = point.map(|axis| axis.div_euclid(period));
+    let fraction = point.map(|axis| {
+        let remainder = axis.rem_euclid(period);
+        ((i128::from(remainder) * i128::from(NOISE_ONE)) / i128::from(period)) as i64
+    });
+    let fade = fraction.map(fade_q15);
+    let mut corners = [0_i64; 8];
+    for (index, output) in corners.iter_mut().enumerate() {
+        *output = i64::from(lattice_value(
+            [
+                lattice[0] + (index & 1) as i64,
+                lattice[1] + ((index >> 1) & 1) as i64,
+                lattice[2] + ((index >> 2) & 1) as i64,
+            ],
+            seed,
+        ));
+    }
+    let x00 = lerp_q15(corners[0], corners[1], fade[0]);
+    let x10 = lerp_q15(corners[2], corners[3], fade[0]);
+    let x01 = lerp_q15(corners[4], corners[5], fade[0]);
+    let x11 = lerp_q15(corners[6], corners[7], fade[0]);
+    let y0 = lerp_q15(x00, x10, fade[1]);
+    let y1 = lerp_q15(x01, x11, fade[1]);
+    lerp_q15(y0, y1, fade[2]) as i32
+}
+
+fn fade_q15(value: i64) -> i64 {
+    // 6t^5 - 15t^4 + 10t^3, evaluated in Q15.
+    let t2 = value.saturating_mul(value) / NOISE_ONE;
+    let t3 = t2.saturating_mul(value) / NOISE_ONE;
+    let polynomial = 10_i64
+        .saturating_mul(NOISE_ONE)
+        .saturating_sub(15_i64.saturating_mul(value))
+        .saturating_add(6_i64.saturating_mul(t2));
+    (t3.saturating_mul(polynomial) / NOISE_ONE).clamp(0, NOISE_ONE)
+}
+
+fn lerp_q15(left: i64, right: i64, weight: i64) -> i64 {
+    left.saturating_add(right.saturating_sub(left).saturating_mul(weight) / NOISE_ONE)
+}
+
+fn lattice_value(point: [i64; 3], seed: u64) -> i32 {
+    let mut value = seed;
+    for (axis, prime) in point.into_iter().zip([
+        0x9e37_79b9_7f4a_7c15_u64,
+        0xbf58_476d_1ce4_e5b9,
+        0x94d0_49bb_1331_11eb,
+    ]) {
+        value ^= (axis as u64).wrapping_mul(prime);
+        value = splitmix64(value);
+    }
+    ((value >> 48) as u16 as i32) - 32_768
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn rotate(point: [i64; 3], octave: u8) -> [i64; 3] {
+    match octave % 6 {
+        0 => point,
+        1 => [point[1], point[2], point[0]],
+        2 => [point[2], point[0], point[1]],
+        3 => [point[0], point[2].saturating_neg(), point[1]],
+        4 => [point[1].saturating_neg(), point[0], point[2]],
+        _ => [point[2], point[1], point[0].saturating_neg()],
     }
 }
 
@@ -140,13 +500,150 @@ fn integer_sqrt(value: u128) -> u128 {
 mod tests {
     use super::*;
 
+    fn volumetric_fixture() -> PlanetSdfGenerator {
+        PlanetSdfGenerator::new(
+            [0; 3],
+            1_000,
+            7,
+            PlanetSdfConfig {
+                seed: 0x5eed,
+                surface_amplitude_cells: 120,
+                surface_period_cells: 512,
+                surface_octaves: 4,
+                overhang_amplitude_cells: 24,
+                overhang_period_cells: 48,
+                cave_depth_cells: 240,
+                cave_period_cells: 64,
+                cave_width_cells: 12,
+            },
+        )
+        .unwrap()
+    }
+
     #[test]
-    fn fixed_sphere_is_stable_and_signed() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 10,
-            material: 7,
-        };
+    fn earthlike_defaults_keep_the_same_physical_scale_at_different_cell_sizes() {
+        let meter = PlanetSdfConfig::earthlike(7, 1_000).unwrap();
+        let decimeter = PlanetSdfConfig::earthlike(7, 100).unwrap();
+
+        assert_eq!(
+            decimeter.surface_amplitude_cells,
+            meter.surface_amplitude_cells * 10
+        );
+        assert_eq!(
+            decimeter.surface_period_cells,
+            meter.surface_period_cells * 10
+        );
+        assert_eq!(
+            decimeter.overhang_amplitude_cells,
+            meter.overhang_amplitude_cells * 10
+        );
+        assert_eq!(decimeter.cave_width_cells, meter.cave_width_cells * 10);
+        assert_eq!(
+            PlanetSdfConfig::earthlike(7, 0),
+            Err(PlanetSdfConfigError::CellSize)
+        );
+    }
+
+    #[test]
+    fn volumetric_planet_is_deterministic_and_config_is_content_addressed() {
+        let generator = volumetric_fixture();
+        let coordinates = [
+            [-1_111, -997, -31],
+            [-1_024, 17, 33],
+            [0, 0, 0],
+            [991, -129, 73],
+            [1_117, 1_009, -47],
+        ];
+        let first = coordinates.map(|point| generator.sample_cell(point));
+        let second = coordinates.map(|point| generator.sample_cell(point));
+        assert_eq!(first, second);
+
+        let mut changed = generator;
+        changed.config.seed ^= 1;
+        assert_ne!(generator.hash(), changed.hash());
+        assert_ne!(
+            generator.hash(),
+            PlanetSdfGenerator::zero_relief_test_fixture(
+                generator.center_cell,
+                generator.radius_cells,
+                generator.material
+            )
+            .hash()
+        );
+    }
+
+    #[test]
+    fn volumetric_planet_has_relief_and_canonical_cave_air() {
+        let generator = volumetric_fixture();
+        let mut surface_radii = Vec::new();
+        for direction in [[1, 0, 0], [0, 1, 0], [0, 0, 1], [-1, 0, 0]] {
+            let radius = (700_i64..=1_300)
+                .find(|radius| {
+                    !generator
+                        .sample_cell(direction.map(|axis| i64::from(axis) * radius))
+                        .is_solid()
+                })
+                .expect("fixture surface must cross the radial trace");
+            surface_radii.push(radius);
+        }
+        assert!(surface_radii.iter().min() != surface_radii.iter().max());
+
+        let cave_air = (-1_200_i64..=1_200).any(|x| {
+            (-1_200_i64..=1_200).step_by(12).any(|y| {
+                let point = [x, y, 0];
+                let radial = integer_sqrt(
+                    point
+                        .iter()
+                        .map(|axis| i128::from(*axis).unsigned_abs().saturating_pow(2))
+                        .sum(),
+                ) as i64;
+                radial < 980 && radial > 760 && !generator.sample_cell(point).is_solid()
+            })
+        });
+        assert!(
+            cave_air,
+            "the configured underground band must contain cave air"
+        );
+    }
+
+    #[test]
+    fn volumetric_summaries_conservatively_contain_samples_across_signed_pages() {
+        let generator = volumetric_fixture();
+        for lod in [0, 1, 3, 5] {
+            for page_x in -3..=2 {
+                for page_y in -2..=1 {
+                    for page_z in -2..=1 {
+                        let key = PageKey::new(lod, [page_x, page_y, page_z]);
+                        let summary = generator.summarize_region(key);
+                        let min = key.lod0_cell_min().unwrap();
+                        let span = key.lod0_cell_span().unwrap();
+                        for dz in [0, span / 2, span - 1] {
+                            for dy in [0, span / 2, span - 1] {
+                                for dx in [0, span / 2, span - 1] {
+                                    let density = i32::from(
+                                        generator
+                                            .sample_cell([min[0] + dx, min[1] + dy, min[2] + dz])
+                                            .density(),
+                                    );
+                                    assert!(
+                                        summary.min_density() <= density
+                                            && density <= summary.max_density(),
+                                        "{key:?} summary {summary:?} missed {density}"
+                                    );
+                                    assert!(!summary.is_uniform_air() || density > 0);
+                                    assert!(!summary.is_uniform_solid() || density <= 0);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn zero_relief_sdf_is_stable_and_signed() {
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 10, 7);
         assert!(generator.sample_cell([0; 3]).is_solid());
         assert_eq!(generator.sample_cell([0; 3]).material(), 7);
         assert!(!generator.sample_cell([20, 0, 0]).is_solid());
@@ -154,12 +651,8 @@ mod tests {
     }
 
     #[test]
-    fn fixed_sphere_summaries_never_reject_sampled_surface_values() {
-        let generator = FixedSphereGenerator {
-            center_cell: [-17, 29, -43],
-            radius_cells: 1_003,
-            material: 7,
-        };
+    fn zero_relief_sdf_summaries_never_reject_sampled_surface_values() {
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([-17, 29, -43], 1_003, 7);
         for lod in [0, 1, 3, 5] {
             let span = PageKey::new(lod, [0; 3]).lod0_cell_span().unwrap();
             let radial_page = (generator.radius_cells as i64).div_euclid(span);

--- a/crates/subsystems/pulsar_terrain/src/lib.rs
+++ b/crates/subsystems/pulsar_terrain/src/lib.rs
@@ -32,7 +32,9 @@ pub use core::{
     TerrainCoreError, TerrainMemoryCounters, TerrainPlanningSnapshot, TerrainWorkCounters,
 };
 pub use edit::{EditError, EditLog, EditMode, EditOp, EditShape};
-pub use generator::{DeterministicGenerator, FixedSphereGenerator};
+pub use generator::{
+    DeterministicGenerator, PlanetSdfConfig, PlanetSdfConfigError, PlanetSdfGenerator,
+};
 pub use hierarchy::{HierarchyError, SparseBrickTree};
 pub use mutation::{
     TerrainOverrideError, TerrainOverrideLog, TerrainOverrideOp, TerrainOverrideTarget,
@@ -77,5 +79,6 @@ pub use streaming::{
 pub use types::{
     CellWord, ContentHash, MaterialId, NodeState, PageId, PageKey, PlanetFrame, PlanetFramePayload,
     PlanetId, PlanetIdParseError, PlanetPosition, PositionError, TerrainNodeSummary,
-    LOD0_CELL_SIZE_METERS, MILLIMETER_INTERACTION_RADIUS_METERS, PAGE_EDGE_CELLS,
+    CUBIC_VOXEL_CELL_SIZE_MM, MILLIMETER_INTERACTION_RADIUS_METERS, PAGE_EDGE_CELLS,
+    SMOOTH_PLANET_DEFAULT_CELL_SIZE_MM,
 };

--- a/crates/subsystems/pulsar_terrain/src/page.rs
+++ b/crates/subsystems/pulsar_terrain/src/page.rs
@@ -401,7 +401,7 @@ pub enum PageCodecError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{EditMode, EditShape, FixedSphereGenerator};
+    use crate::{EditMode, EditShape, PlanetSdfGenerator};
 
     #[test]
     fn constant_and_dense_pages_round_trip_with_stable_hashes() {
@@ -494,11 +494,7 @@ mod tests {
 
     #[test]
     fn incremental_edit_tail_matches_full_deterministic_replay() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 24,
-            material: 2,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 24, 2);
         let first = EditOp {
             sequence: 1,
             stable_id: [1; 16],
@@ -532,11 +528,7 @@ mod tests {
 
     #[test]
     fn coarse_pages_sample_the_same_canonical_field_in_fixed_work() {
-        let generator = FixedSphereGenerator {
-            center_cell: [-40, 17, 9],
-            radius_cells: 180,
-            material: 6,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([-40, 17, 9], 180, 6);
         let edit = EditOp {
             sequence: 1,
             stable_id: [3; 16],
@@ -564,11 +556,7 @@ mod tests {
 
     #[test]
     fn coincident_samples_match_across_lods_and_negative_page_boundaries() {
-        let generator = FixedSphereGenerator {
-            center_cell: [-20, 10, 5],
-            radius_cells: 90,
-            material: 4,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([-20, 10, 5], 90, 4);
         let edits = EditLog::default();
         let coarse_key = PageKey::new(1, [-1, 0, 0]);
         let fine_key = PageKey::new(0, [-2, 0, 0]);

--- a/crates/subsystems/pulsar_terrain/src/persistence.rs
+++ b/crates/subsystems/pulsar_terrain/src/persistence.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ContentHash, DeterministicGenerator, FixedSphereGenerator, PlanetDefinition, PlanetId,
+    ContentHash, DeterministicGenerator, PlanetDefinition, PlanetId, PlanetSdfGenerator,
     TerrainCore, TerrainPlanningHandle, TerrainRuntimeError, TerrainRuntimeHandle, TerrainSnapshot,
     TerrainStore,
 };
@@ -162,7 +162,9 @@ pub enum TerrainPersistenceError {
     ThreadSpawn,
     #[error("terrain persistence request queue capacity {capacity} is exhausted")]
     RequestBackpressure { capacity: usize },
-    #[error("terrain persistence retained-byte budget {capacity} cannot reserve {requested} bytes")]
+    #[error(
+        "terrain persistence retained-byte budget {capacity} cannot reserve {requested} bytes"
+    )]
     SnapshotByteBackpressure { requested: usize, capacity: usize },
     #[error("planet {planet_id:?} already has an incompatible persistence operation in flight")]
     PlanetBusy { planet_id: PlanetId },
@@ -223,7 +225,7 @@ struct RestoreReady {
     record_generation: u64,
     snapshot_hash: ContentHash,
     retained_bytes: usize,
-    core: Option<TerrainCore<FixedSphereGenerator>>,
+    core: Option<TerrainCore<PlanetSdfGenerator>>,
 }
 
 enum PersistenceWorkerResult {
@@ -844,11 +846,11 @@ fn execute_job(job: &PersistenceJob, max_snapshot_bytes: usize) -> PersistenceWo
                         message: "stored snapshot belongs to a different planet".to_string(),
                     };
                 }
-                let generator = FixedSphereGenerator {
-                    center_cell: job.identity.definition.center_cell,
-                    radius_cells: job.identity.definition.radius_cells,
-                    material: job.identity.definition.material,
-                };
+                let generator = job
+                    .identity
+                    .definition
+                    .generator()
+                    .expect("persistence jobs capture validated planet definitions");
                 if snapshot.generator_hash != generator.hash()
                     || snapshot.hierarchy.root_lod() != job.identity.definition.root_lod
                 {
@@ -914,6 +916,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 100,
             material: id.max(1),
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 12,
             max_resident_pages: 16,
         }
@@ -1095,7 +1099,8 @@ mod tests {
             .submit(
                 definition.planet_id,
                 PlanetView::new(
-                    PlanetPosition::from_lod0_cell([200, 0, 0]),
+                    PlanetPosition::from_lod0_cell([200, 0, 0], definition.lod0_cell_size_mm)
+                        .unwrap(),
                     [-1.0, 0.0, 0.0],
                     [0.0, 1.0, 0.0],
                     60_f64.to_radians(),

--- a/crates/subsystems/pulsar_terrain/src/planet.rs
+++ b/crates/subsystems/pulsar_terrain/src/planet.rs
@@ -1,4 +1,4 @@
-use crate::PlanetId;
+use crate::{PlanetId, PlanetSdfConfig, PlanetSdfConfigError, PlanetSdfGenerator};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlanetDefinition {
@@ -6,11 +6,21 @@ pub struct PlanetDefinition {
     pub center_cell: [i64; 3],
     pub radius_cells: u64,
     pub material: u8,
+    pub lod0_cell_size_mm: u32,
+    pub sdf: PlanetSdfConfig,
     pub root_lod: u8,
     pub max_resident_pages: usize,
 }
 
 impl PlanetDefinition {
+    pub fn lod0_cell_size_m(&self) -> f64 {
+        f64::from(self.lod0_cell_size_mm) / 1_000.0
+    }
+
+    pub fn generator(&self) -> Result<PlanetSdfGenerator, PlanetSdfConfigError> {
+        PlanetSdfGenerator::new(self.center_cell, self.radius_cells, self.material, self.sdf)
+    }
+
     /// Whether every discrete cell touched by the spherical source fits the
     /// centered sparse hierarchy root represented by `root_lod`.
     pub fn fits_centered_root(&self) -> bool {
@@ -18,7 +28,10 @@ impl PlanetDefinition {
             return false;
         }
         let half_span = i128::from(crate::PAGE_EDGE_CELLS) << (self.root_lod - 1);
-        let radius = i128::from(self.radius_cells);
+        let radius = i128::from(
+            self.radius_cells
+                .saturating_add(self.sdf.maximum_displacement_cells()),
+        );
         self.center_cell.iter().all(|axis| {
             let center = i128::from(*axis);
             center - radius >= -half_span && center + radius < half_span
@@ -37,6 +50,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 63_710_000,
             material: 1,
+            lod0_cell_size_mm: 100,
+            sdf: PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 22,
             max_resident_pages: 8_192,
         };

--- a/crates/subsystems/pulsar_terrain/src/planning.rs
+++ b/crates/subsystems/pulsar_terrain/src/planning.rs
@@ -1,7 +1,7 @@
 use crate::{
-    FixedSphereGenerator, PlanetDefinition, PlanetId, PlanetView, TerrainCore,
-    TerrainPlanningSnapshot, TerrainRuntimeError, TerrainRuntimeHandle, TerrainStreamingConfig,
-    TerrainStreamingError, TerrainStreamingPlan, TerrainStreamingPlanner,
+    PlanetDefinition, PlanetId, PlanetView, TerrainCore, TerrainPlanningSnapshot,
+    TerrainRuntimeError, TerrainRuntimeHandle, TerrainStreamingConfig, TerrainStreamingError,
+    TerrainStreamingPlan, TerrainStreamingPlanner,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
@@ -530,11 +530,10 @@ fn planning_worker_loop(shared: Arc<PlanningShared>, runtime: TerrainRuntimeHand
             continue;
         };
         let capture_elapsed = capture_started.elapsed();
-        let generator = FixedSphereGenerator {
-            center_cell: capture.definition.center_cell,
-            radius_cells: capture.definition.radius_cells,
-            material: capture.definition.material,
-        };
+        let generator = capture
+            .definition
+            .generator()
+            .expect("planning captures validated planet definitions");
         let started = Instant::now();
         let plan = TerrainCore::from_planning_snapshot(capture.snapshot, generator)
             .map_err(|error| TerrainStreamingError::TerrainSummary(error.to_string()))
@@ -609,6 +608,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 1_000,
             material: id.max(1),
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 8,
             max_resident_pages: 512,
         }
@@ -634,7 +635,7 @@ mod tests {
 
     fn view(camera: [i64; 3], forward: [f64; 3], velocity_mps: [f64; 3]) -> PlanetView {
         PlanetView::new(
-            PlanetPosition::from_lod0_cell(camera),
+            PlanetPosition::from_lod0_cell(camera, 100).unwrap(),
             forward,
             [0.0, 1.0, 0.0],
             60_f64.to_radians(),
@@ -735,7 +736,7 @@ mod tests {
         let result = wait_for_submission(&planning, latest.submission);
         let expected = TerrainStreamingPlanner::new(config.streaming)
             .unwrap()
-            .plan_fixed_sphere(&planet, views[4])
+            .plan_planet(&planet, views[4])
             .unwrap();
         assert_eq!(result.into_plan().unwrap(), expected);
         let counters = planning.counters();

--- a/crates/subsystems/pulsar_terrain/src/refinement.rs
+++ b/crates/subsystems/pulsar_terrain/src/refinement.rs
@@ -1221,6 +1221,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 1_000,
             material: 1,
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 6,
             max_resident_pages: 256,
         };
@@ -1233,7 +1235,7 @@ mod tests {
         })
         .unwrap();
         let view = PlanetView::new(
-            PlanetPosition::from_lod0_cell([-1_000, 0, 0]),
+            PlanetPosition::from_lod0_cell([-1_000, 0, 0], 100).unwrap(),
             [1.0, 0.0, 0.0],
             [0.0, 1.0, 0.0],
             60_f64.to_radians(),
@@ -1243,7 +1245,7 @@ mod tests {
             [0.0; 3],
         )
         .unwrap();
-        let target = planner.plan_fixed_sphere(&definition, view).unwrap();
+        let target = planner.plan_planet(&definition, view).unwrap();
         assert!(target
             .demands()
             .iter()
@@ -1283,6 +1285,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 1_000,
             material: 1,
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 6,
             max_resident_pages: 64,
         };
@@ -1296,7 +1300,7 @@ mod tests {
         .unwrap();
         let make_view = |cell, look| {
             PlanetView::new(
-                PlanetPosition::from_lod0_cell(cell),
+                PlanetPosition::from_lod0_cell(cell, 100).unwrap(),
                 look,
                 [0.0, 1.0, 0.0],
                 60_f64.to_radians(),
@@ -1308,10 +1312,10 @@ mod tests {
             .unwrap()
         };
         let ground = planner
-            .plan_fixed_sphere(&definition, make_view([1_000, 0, 0], [-1.0, 0.0, 0.0]))
+            .plan_planet(&definition, make_view([1_000, 0, 0], [-1.0, 0.0, 0.0]))
             .unwrap();
         let orbit = planner
-            .plan_fixed_sphere(&definition, make_view([100_000, 0, 0], [-1.0, 0.0, 0.0]))
+            .plan_planet(&definition, make_view([100_000, 0, 0], [-1.0, 0.0, 0.0]))
             .unwrap();
         assert!(ground.demands().len() > orbit.demands().len());
 

--- a/crates/subsystems/pulsar_terrain/src/render.rs
+++ b/crates/subsystems/pulsar_terrain/src/render.rs
@@ -873,6 +873,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 1_000,
             material: id.max(1),
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 6,
             max_resident_pages: 64,
         }

--- a/crates/subsystems/pulsar_terrain/src/runtime.rs
+++ b/crates/subsystems/pulsar_terrain/src/runtime.rs
@@ -6,9 +6,9 @@ use crate::planning::{
     TerrainPlanningCapture, TerrainPlanningHandle, TerrainPlanningIdentity, TerrainPlanningService,
 };
 use crate::{
-    CELL_COUNT, CompactedPageRecord, EditOp, FixedSphereGenerator, PageBuildCommitOutcome,
-    PageBuildPreparation, PageBuildRequest, PageBuildResult, PageKey, PlanetDefinition, PlanetId,
-    TerrainCore, TerrainCoreError, TerrainOverrideOp, TerrainOverrideTarget,
+    CompactedPageRecord, EditOp, PageBuildCommitOutcome, PageBuildPreparation, PageBuildRequest,
+    PageBuildResult, PageKey, PlanetDefinition, PlanetId, PlanetSdfGenerator, TerrainCore,
+    TerrainCoreError, TerrainOverrideOp, TerrainOverrideTarget, CELL_COUNT,
 };
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use engine_subsystems::{Subsystem, SubsystemContext, SubsystemError, SubsystemId};
@@ -301,7 +301,7 @@ struct ActiveRequest {
 
 struct WorkJob {
     identity: RequestIdentity,
-    request: PageBuildRequest<FixedSphereGenerator>,
+    request: PageBuildRequest<PlanetSdfGenerator>,
     class: TerrainRequestClass,
     deadline_tick: u64,
     order: u64,
@@ -411,17 +411,15 @@ impl WorkQueue {
 struct PlanetRuntime {
     definition: PlanetDefinition,
     generation: u64,
-    core: TerrainCore<FixedSphereGenerator>,
+    core: TerrainCore<PlanetSdfGenerator>,
     page_generations: BTreeMap<PageKey, u64>,
 }
 
 impl PlanetRuntime {
     fn new(definition: PlanetDefinition, generation: u64) -> Result<Self, TerrainCoreError> {
-        let generator = FixedSphereGenerator {
-            center_cell: definition.center_cell,
-            radius_cells: definition.radius_cells,
-            material: definition.material,
-        };
+        let generator = definition
+            .generator()
+            .expect("planet definitions are validated before runtime construction");
         let core = TerrainCore::new(definition.planet_id, definition.root_lod, generator)?;
         Ok(Self {
             definition,
@@ -825,7 +823,7 @@ impl TerrainRuntimeHandle {
         publish: F,
     ) -> Result<(), TerrainRuntimeError>
     where
-        F: FnOnce(&mut TerrainCore<FixedSphereGenerator>) -> Result<(), TerrainCoreError>,
+        F: FnOnce(&mut TerrainCore<PlanetSdfGenerator>) -> Result<(), TerrainCoreError>,
     {
         let bounds = match target {
             TerrainOverrideTarget::Root => None,
@@ -855,7 +853,7 @@ impl TerrainRuntimeHandle {
         publish: F,
     ) -> Result<(), TerrainRuntimeError>
     where
-        F: FnOnce(&mut TerrainCore<FixedSphereGenerator>) -> Result<(), TerrainCoreError>,
+        F: FnOnce(&mut TerrainCore<PlanetSdfGenerator>) -> Result<(), TerrainCoreError>,
     {
         let mut state = lock(&self.shared.state);
         if !state.running {
@@ -1472,6 +1470,13 @@ impl TerrainRuntimeHandle {
             .map(|planet| planet.generation)
     }
 
+    pub fn planet_definition(&self, planet_id: PlanetId) -> Option<PlanetDefinition> {
+        lock(&self.shared.state)
+            .planets
+            .get(&planet_id)
+            .map(|planet| planet.definition.clone())
+    }
+
     pub(crate) fn persistence_identity(
         &self,
         planet_id: PlanetId,
@@ -1516,7 +1521,7 @@ impl TerrainRuntimeHandle {
         definition: PlanetDefinition,
         expected_planet_generation: u64,
         expected_terrain_sequence: u64,
-        restored: &mut Option<TerrainCore<FixedSphereGenerator>>,
+        restored: &mut Option<TerrainCore<PlanetSdfGenerator>>,
     ) -> Result<TerrainPersistenceRestoreCommit, TerrainRuntimeError> {
         let planet_id = definition.planet_id;
         let mut state = lock(&self.shared.state);
@@ -1962,11 +1967,13 @@ fn validate_definition(
     config: &TerrainRuntimeConfig,
 ) -> Result<(), TerrainRuntimeError> {
     if definition.radius_cells == 0
+        || definition.lod0_cell_size_mm == 0
         || definition.material == 0
         || !(1..=62).contains(&definition.root_lod)
         || !definition.fits_centered_root()
         || definition.max_resident_pages == 0
         || definition.max_resident_pages > config.max_resident_pages
+        || definition.sdf.validate().is_err()
     {
         return Err(TerrainRuntimeError::InvalidConfig(
             "planet definition exceeds the runtime contract",
@@ -2047,6 +2054,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells: 100,
             material: id.max(1),
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod: 12,
             max_resident_pages: 8,
         }

--- a/crates/subsystems/pulsar_terrain/src/store.rs
+++ b/crates/subsystems/pulsar_terrain/src/store.rs
@@ -221,7 +221,7 @@ pub enum TerrainStoreError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FixedSphereGenerator, NodeState, PageKey, PlanetId, TerrainCore};
+    use crate::{NodeState, PageKey, PlanetId, PlanetSdfGenerator, TerrainCore};
 
     #[test]
     fn interrupted_publish_keeps_the_previous_valid_root() {
@@ -272,11 +272,7 @@ mod tests {
         virtual_fs::reset_to_local();
         let temporary = tempfile::tempdir().unwrap();
         let store = TerrainStore::new(temporary.path().join("terrain"));
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 7,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 7);
         let key = PageKey::new(0, [0; 3]);
         let mut core = TerrainCore::new(PlanetId([7; 16]), 12, generator).unwrap();
         core.compact_page(key).unwrap();
@@ -301,11 +297,7 @@ mod tests {
         virtual_fs::reset_to_local();
         let temporary = tempfile::tempdir().unwrap();
         let store = TerrainStore::new(temporary.path().join("terrain"));
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 7,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 7);
         let core = TerrainCore::new(PlanetId([8; 16]), 12, generator).unwrap();
         let expected = core.snapshot();
         let first = store.save_snapshot(&expected).unwrap();
@@ -359,11 +351,7 @@ mod tests {
         virtual_fs::reset_to_local();
         let temporary = tempfile::tempdir().unwrap();
         let store = TerrainStore::new(temporary.path().join("terrain"));
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 7,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 7);
         let expected = TerrainCore::new(PlanetId([9; 16]), 12, generator)
             .unwrap()
             .snapshot();

--- a/crates/subsystems/pulsar_terrain/src/streaming.rs
+++ b/crates/subsystems/pulsar_terrain/src/streaming.rs
@@ -1,6 +1,6 @@
 use crate::{
-    DeterministicGenerator, FixedSphereGenerator, PageKey, PlanetDefinition, PlanetId,
-    PlanetPosition, TerrainNodeSummary, TerrainRequestClass, LOD0_CELL_SIZE_METERS,
+    DeterministicGenerator, PageKey, PlanetDefinition, PlanetId, PlanetPosition,
+    PlanetSdfGenerator, TerrainNodeSummary, TerrainRequestClass,
 };
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};
@@ -34,7 +34,7 @@ pub trait TerrainRegionClassifier {
     }
 }
 
-impl TerrainRegionClassifier for FixedSphereGenerator {
+impl TerrainRegionClassifier for PlanetSdfGenerator {
     fn summarize_region(&self, key: PageKey) -> Result<TerrainNodeSummary, TerrainStreamingError> {
         Ok(DeterministicGenerator::summarize_region(self, key))
     }
@@ -519,16 +519,14 @@ impl TerrainStreamingPlanner {
         self.config
     }
 
-    pub fn plan_fixed_sphere(
+    pub fn plan_planet(
         &self,
         definition: &PlanetDefinition,
         view: PlanetView,
     ) -> Result<TerrainStreamingPlan, TerrainStreamingError> {
-        let classifier = FixedSphereGenerator {
-            center_cell: definition.center_cell,
-            radius_cells: definition.radius_cells,
-            material: definition.material,
-        };
+        let classifier = definition
+            .generator()
+            .map_err(|error| TerrainStreamingError::TerrainSummary(error.to_string()))?;
         self.plan_with_classifier(definition, view, &classifier)
     }
 
@@ -539,6 +537,11 @@ impl TerrainStreamingPlanner {
         classifier: &C,
     ) -> Result<TerrainStreamingPlan, TerrainStreamingError> {
         validate_planet_root(definition)?;
+        if view.camera().lod0_cell_size_mm() != definition.lod0_cell_size_mm {
+            return Err(TerrainStreamingError::InvalidView(
+                "camera and planet definition must use the same LOD0 cell size",
+            ));
+        }
         let page_budget = self.config.max_pages.min(definition.max_resident_pages);
         let geometry = ViewGeometry::new(view, self.config)?;
         let mut state = PlannerState {
@@ -806,6 +809,7 @@ struct ViewGeometry {
     interaction_radius_m: f64,
     target_projected_error_px: f64,
     focal_length_px: f64,
+    lod0_cell_size_m: f64,
 }
 
 impl ViewGeometry {
@@ -846,6 +850,7 @@ impl ViewGeometry {
             interaction_radius_m: config.interaction_radius_m,
             target_projected_error_px: config.target_projected_error_px,
             focal_length_px,
+            lod0_cell_size_m: view.camera.lod0_cell_size_m(),
         })
     }
 
@@ -872,7 +877,7 @@ impl ViewGeometry {
         } else {
             predicted_distance
         };
-        let geometric_error_m = geometric_error_lod0_cells as f64 * LOD0_CELL_SIZE_METERS;
+        let geometric_error_m = geometric_error_lod0_cells as f64 * self.lod0_cell_size_m;
         let error_distance = current_distance
             .min(predicted_distance)
             .max(geometric_error_m * 0.5)
@@ -945,8 +950,8 @@ impl RelativeAabb {
             let delta = min_cell[axis]
                 .checked_sub(camera_cell[axis])
                 .ok_or(TerrainStreamingError::CoordinateOverflow)?;
-            min[axis] = delta as f64 * LOD0_CELL_SIZE_METERS - camera_subcell[axis];
-            max[axis] = min[axis] + span as f64 * LOD0_CELL_SIZE_METERS;
+            min[axis] = delta as f64 * camera.lod0_cell_size_m() - camera_subcell[axis];
+            max[axis] = min[axis] + span as f64 * camera.lod0_cell_size_m();
         }
         Ok(Self { min, max })
     }
@@ -1227,6 +1232,8 @@ mod tests {
             center_cell: [0; 3],
             radius_cells,
             material: 3,
+            lod0_cell_size_mm: 100,
+            sdf: crate::PlanetSdfConfig::zero_relief_test_fixture(),
             root_lod,
             max_resident_pages: max_pages,
         }
@@ -1234,7 +1241,7 @@ mod tests {
 
     fn view(camera: [i64; 3], forward: [f64; 3], velocity: [f64; 3]) -> PlanetView {
         PlanetView::new(
-            PlanetPosition::from_lod0_cell(camera),
+            PlanetPosition::from_lod0_cell(camera, 100).unwrap(),
             forward,
             [0.0, 1.0, 0.0],
             60_f64.to_radians(),
@@ -1247,12 +1254,8 @@ mod tests {
     }
 
     #[test]
-    fn fixed_sphere_classifier_prunes_uniform_space_conservatively() {
-        let generator = FixedSphereGenerator {
-            center_cell: [0; 3],
-            radius_cells: 100,
-            material: 1,
-        };
+    fn zero_relief_sdf_classifier_prunes_uniform_space_conservatively() {
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 100, 1);
         assert_eq!(
             generator
                 .classify_region(PageKey::new(0, [20, 20, 20]))
@@ -1271,10 +1274,11 @@ mod tests {
                 .unwrap(),
             TerrainRegion::Surface
         );
-        let large = FixedSphereGenerator {
-            radius_cells: 10_000,
-            ..generator
-        };
+        let large = PlanetSdfGenerator::zero_relief_test_fixture(
+            generator.center_cell,
+            10_000,
+            generator.material,
+        );
         assert_eq!(
             large.classify_region(PageKey::new(0, [0, 0, 0])).unwrap(),
             TerrainRegion::UniformSolid
@@ -1293,8 +1297,8 @@ mod tests {
         })
         .unwrap();
         let view = view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]);
-        let first = planner.plan_fixed_sphere(&definition, view).unwrap();
-        let second = planner.plan_fixed_sphere(&definition, view).unwrap();
+        let first = planner.plan_planet(&definition, view).unwrap();
+        let second = planner.plan_planet(&definition, view).unwrap();
         assert_eq!(first, second);
         assert!(first.demands().len() <= 4_096);
         assert!(first.counters().traversed_nodes <= 65_536);
@@ -1327,11 +1331,11 @@ mod tests {
         }
 
         let definition = definition(1_000, 6, 4_096);
-        let generator = FixedSphereGenerator {
-            center_cell: definition.center_cell,
-            radius_cells: definition.radius_cells,
-            material: definition.material,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture(
+            definition.center_cell,
+            definition.radius_cells,
+            definition.material,
+        );
         let core =
             crate::TerrainCore::new(definition.planet_id, definition.root_lod, generator).unwrap();
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
@@ -1343,7 +1347,7 @@ mod tests {
         })
         .unwrap();
         let view = view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]);
-        let direct = planner.plan_fixed_sphere(&definition, view).unwrap();
+        let direct = planner.plan_planet(&definition, view).unwrap();
         let authoritative = planner
             .plan_with_classifier(&definition, view, &core)
             .unwrap();
@@ -1365,11 +1369,11 @@ mod tests {
     #[test]
     fn authoritative_planning_sees_fine_edits_outside_the_procedural_surface() {
         let definition = definition(100, 6, 4_096);
-        let generator = FixedSphereGenerator {
-            center_cell: definition.center_cell,
-            radius_cells: definition.radius_cells,
-            material: definition.material,
-        };
+        let generator = PlanetSdfGenerator::zero_relief_test_fixture(
+            definition.center_cell,
+            definition.radius_cells,
+            definition.material,
+        );
         let mut core =
             crate::TerrainCore::new(definition.planet_id, definition.root_lod, generator).unwrap();
         core.append_edit(crate::EditOp {
@@ -1391,7 +1395,7 @@ mod tests {
         })
         .unwrap();
         let view = view([620, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]);
-        let procedural = planner.plan_fixed_sphere(&definition, view).unwrap();
+        let procedural = planner.plan_planet(&definition, view).unwrap();
         let authoritative = planner
             .plan_with_classifier(&definition, view, &core)
             .unwrap();
@@ -1420,7 +1424,7 @@ mod tests {
         })
         .unwrap();
         let plan = planner
-            .plan_fixed_sphere(&definition, view([-1_000, 0, 0], [1.0, 0.0, 0.0], [0.0; 3]))
+            .plan_planet(&definition, view([-1_000, 0, 0], [1.0, 0.0, 0.0], [0.0; 3]))
             .unwrap();
         assert!(plan.is_face_balanced());
         assert!(plan
@@ -1443,7 +1447,7 @@ mod tests {
         .unwrap();
         let camera = i64::try_from(radius).unwrap() + 40_000_000;
         let plan = planner
-            .plan_fixed_sphere(
+            .plan_planet(
                 &definition,
                 view([camera, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]),
             )
@@ -1460,11 +1464,11 @@ mod tests {
     #[test]
     fn ground_refinement_preserves_complete_coarse_planet_coverage() {
         let definition = definition(1_000, 6, 4_096);
-        let classifier = FixedSphereGenerator {
-            center_cell: definition.center_cell,
-            radius_cells: definition.radius_cells,
-            material: definition.material,
-        };
+        let classifier = PlanetSdfGenerator::zero_relief_test_fixture(
+            definition.center_cell,
+            definition.radius_cells,
+            definition.material,
+        );
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 8.0,
             max_pages: 4_096,
@@ -1473,7 +1477,7 @@ mod tests {
         })
         .unwrap();
         let plan = planner
-            .plan_fixed_sphere(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
+            .plan_planet(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
             .unwrap();
 
         let root_child_lod = definition.root_lod - 1;
@@ -1505,7 +1509,7 @@ mod tests {
     }
 
     #[test]
-    fn astronomical_view_collapses_to_the_complete_root_shell() {
+    fn astronomical_view_collapses_to_complete_coarse_coverage() {
         let radius = 63_710_000_u64;
         let definition = definition(radius, 22, 2_048);
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
@@ -1518,7 +1522,7 @@ mod tests {
         .unwrap();
         let camera = i64::try_from(radius).unwrap() + 1_500_000_000_000;
         let plan = planner
-            .plan_fixed_sphere(
+            .plan_planet(
                 &definition,
                 view([camera, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]),
             )
@@ -1549,7 +1553,7 @@ mod tests {
         })
         .unwrap();
         let plan = planner
-            .plan_fixed_sphere(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
+            .plan_planet(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
             .unwrap();
         assert!(plan.demands().len() <= 32);
         assert!(plan.limits().contains(&TerrainStreamingLimit::PageBudget));
@@ -1569,7 +1573,7 @@ mod tests {
         })
         .unwrap();
         let plan = planner
-            .plan_fixed_sphere(
+            .plan_planet(
                 &definition,
                 view([2_000, 0, 0], [-1.0, 0.0, 0.0], [0.0, 100.0, 0.0]),
             )
@@ -1590,7 +1594,7 @@ mod tests {
         })
         .unwrap();
         let plan = planner
-            .plan_fixed_sphere(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
+            .plan_planet(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
             .unwrap();
         assert_eq!(plan.counters().traversed_nodes, 8);
         assert!(plan
@@ -1611,10 +1615,10 @@ mod tests {
         })
         .unwrap();
         let ground = planner
-            .plan_fixed_sphere(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
+            .plan_planet(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
             .unwrap();
         let antipode = planner
-            .plan_fixed_sphere(&definition, view([-1_000, 0, 0], [1.0, 0.0, 0.0], [0.0; 3]))
+            .plan_planet(&definition, view([-1_000, 0, 0], [1.0, 0.0, 0.0], [0.0; 3]))
             .unwrap();
         assert!(ground.demands().len() <= 1_024);
         assert!(antipode.demands().len() <= 1_024);
@@ -1627,7 +1631,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig::default()).unwrap();
         let too_deep = definition(1, 59, 8_192);
         assert_eq!(
-            planner.plan_fixed_sphere(&too_deep, view([0, 0, 10], [0.0, 0.0, -1.0], [0.0; 3])),
+            planner.plan_planet(&too_deep, view([0, 0, 10], [0.0, 0.0, -1.0], [0.0; 3])),
             Err(TerrainStreamingError::UnsupportedRootLod(59))
         );
 
@@ -1636,7 +1640,7 @@ mod tests {
             ..definition(100, 4, 8_192)
         };
         assert_eq!(
-            planner.plan_fixed_sphere(&outside, view([0, 0, 10], [0.0, 0.0, -1.0], [0.0; 3])),
+            planner.plan_planet(&outside, view([0, 0, 10], [0.0, 0.0, -1.0], [0.0; 3])),
             Err(TerrainStreamingError::PlanetOutsideRoot)
         );
     }

--- a/crates/subsystems/pulsar_terrain/src/types.rs
+++ b/crates/subsystems/pulsar_terrain/src/types.rs
@@ -3,7 +3,8 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 pub type MaterialId = u8;
-pub const LOD0_CELL_SIZE_METERS: f64 = 0.1;
+pub const SMOOTH_PLANET_DEFAULT_CELL_SIZE_MM: u32 = 1_000;
+pub const CUBIC_VOXEL_CELL_SIZE_MM: u32 = 100;
 pub const PAGE_EDGE_CELLS: i64 = 32;
 pub const MILLIMETER_INTERACTION_RADIUS_METERS: f64 = 8_192.0;
 
@@ -51,16 +52,18 @@ pub enum PlanetIdParseError {
     Hex { offset: usize },
 }
 
-/// Authoritative planet-space position at 10 cm LOD0 resolution.
+/// Authoritative planet-space position at an explicit per-planet LOD0 scale.
 ///
 /// `lod0_cell` is the persistent integer address. `subcell_m` is private and
-/// normalized to `[0, 0.1)` meters on every axis, including negative world
-/// coordinates. Serde deserialization runs the same validation as `new`.
+/// normalized to one LOD0 cell on every axis, including negative world
+/// coordinates. The scale is part of the canonical value so positions from
+/// different planet definitions cannot be mixed accidentally.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "PlanetPositionWire", into = "PlanetPositionWire")]
 pub struct PlanetPosition {
     lod0_cell: [i64; 3],
     subcell_m: [f64; 3],
+    lod0_cell_size_mm: u32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
@@ -68,15 +71,21 @@ pub struct PlanetPosition {
 struct PlanetPositionWire {
     lod0_cell: [i64; 3],
     subcell_m: [f64; 3],
+    lod0_cell_size_mm: u32,
 }
 
 impl PlanetPosition {
-    pub fn new(lod0_cell: [i64; 3], mut subcell_m: [f64; 3]) -> Result<Self, PositionError> {
+    pub fn new(
+        lod0_cell: [i64; 3],
+        mut subcell_m: [f64; 3],
+        lod0_cell_size_mm: u32,
+    ) -> Result<Self, PositionError> {
+        let cell_size_m = cell_size_meters(lod0_cell_size_mm)?;
         for value in &mut subcell_m {
             if !value.is_finite() {
                 return Err(PositionError::NonFinite);
             }
-            if !(0.0..LOD0_CELL_SIZE_METERS).contains(value) {
+            if !(0.0..cell_size_m).contains(value) {
                 return Err(PositionError::SubcellOutOfRange);
             }
             if *value == -0.0 {
@@ -86,19 +95,26 @@ impl PlanetPosition {
         Ok(Self {
             lod0_cell,
             subcell_m,
+            lod0_cell_size_mm,
         })
     }
 
-    pub const fn from_lod0_cell(lod0_cell: [i64; 3]) -> Self {
-        Self {
+    pub fn from_lod0_cell(
+        lod0_cell: [i64; 3],
+        lod0_cell_size_mm: u32,
+    ) -> Result<Self, PositionError> {
+        let _ = cell_size_meters(lod0_cell_size_mm)?;
+        Ok(Self {
             lod0_cell,
             subcell_m: [0.0; 3],
-        }
+            lod0_cell_size_mm,
+        })
     }
 
     /// Convenience conversion for camera/input values. Terrain persistence and
     /// replication should carry the canonical cell-plus-remainder form.
-    pub fn from_meters(meters: [f64; 3]) -> Result<Self, PositionError> {
+    pub fn from_meters(meters: [f64; 3], lod0_cell_size_mm: u32) -> Result<Self, PositionError> {
+        let cell_size_m = cell_size_meters(lod0_cell_size_mm)?;
         let mut cells = [0_i64; 3];
         let mut subcell_m = [0.0_f64; 3];
         for axis in 0..3 {
@@ -106,26 +122,26 @@ impl PlanetPosition {
             if !value.is_finite() {
                 return Err(PositionError::NonFinite);
             }
-            let cell = (value / LOD0_CELL_SIZE_METERS).floor();
+            let cell = (value / cell_size_m).floor();
             if cell < i64::MIN as f64 || cell >= -(i64::MIN as f64) {
                 return Err(PositionError::CoordinateOverflow);
             }
             cells[axis] = cell as i64;
-            let mut remainder = value - cell * LOD0_CELL_SIZE_METERS;
+            let mut remainder = value - cell * cell_size_m;
             if remainder < 0.0 {
                 cells[axis] = cells[axis]
                     .checked_sub(1)
                     .ok_or(PositionError::CoordinateOverflow)?;
-                remainder += LOD0_CELL_SIZE_METERS;
-            } else if remainder >= LOD0_CELL_SIZE_METERS {
+                remainder += cell_size_m;
+            } else if remainder >= cell_size_m {
                 cells[axis] = cells[axis]
                     .checked_add(1)
                     .ok_or(PositionError::CoordinateOverflow)?;
-                remainder -= LOD0_CELL_SIZE_METERS;
+                remainder -= cell_size_m;
             }
             subcell_m[axis] = remainder;
         }
-        Self::new(cells, subcell_m)
+        Self::new(cells, subcell_m, lod0_cell_size_mm)
     }
 
     pub const fn lod0_cell(self) -> [i64; 3] {
@@ -136,15 +152,27 @@ impl PlanetPosition {
         self.subcell_m
     }
 
+    pub const fn lod0_cell_size_mm(self) -> u32 {
+        self.lod0_cell_size_mm
+    }
+
+    pub fn lod0_cell_size_m(self) -> f64 {
+        f64::from(self.lod0_cell_size_mm) / 1_000.0
+    }
+
     /// Computes `self - origin` before any conversion to floating point.
     pub fn relative_meters(self, origin: Self) -> Result<[f64; 3], PositionError> {
+        if self.lod0_cell_size_mm != origin.lod0_cell_size_mm {
+            return Err(PositionError::ScaleMismatch);
+        }
+        let cell_size_m = self.lod0_cell_size_m();
         let mut relative = [0.0_f64; 3];
         for (axis, output) in relative.iter_mut().enumerate() {
             let cell_delta = self.lod0_cell[axis]
                 .checked_sub(origin.lod0_cell[axis])
                 .ok_or(PositionError::CoordinateOverflow)?;
-            *output = cell_delta as f64 * LOD0_CELL_SIZE_METERS
-                + (self.subcell_m[axis] - origin.subcell_m[axis]);
+            *output =
+                cell_delta as f64 * cell_size_m + (self.subcell_m[axis] - origin.subcell_m[axis]);
         }
         Ok(relative)
     }
@@ -153,13 +181,17 @@ impl PlanetPosition {
         self,
         origin_lod0_cell: [i64; 3],
     ) -> Result<[f64; 3], PositionError> {
-        self.relative_meters(Self::from_lod0_cell(origin_lod0_cell))
+        self.relative_meters(Self::from_lod0_cell(
+            origin_lod0_cell,
+            self.lod0_cell_size_mm,
+        )?)
     }
 }
 
 impl Default for PlanetPosition {
     fn default() -> Self {
-        Self::from_lod0_cell([0; 3])
+        Self::from_lod0_cell([0; 3], SMOOTH_PLANET_DEFAULT_CELL_SIZE_MM)
+            .expect("the default smooth-planet scale is valid")
     }
 }
 
@@ -167,7 +199,7 @@ impl TryFrom<PlanetPositionWire> for PlanetPosition {
     type Error = PositionError;
 
     fn try_from(value: PlanetPositionWire) -> Result<Self, Self::Error> {
-        Self::new(value.lod0_cell, value.subcell_m)
+        Self::new(value.lod0_cell, value.subcell_m, value.lod0_cell_size_mm)
     }
 }
 
@@ -176,6 +208,7 @@ impl From<PlanetPosition> for PlanetPositionWire {
         Self {
             lod0_cell: value.lod0_cell,
             subcell_m: value.subcell_m,
+            lod0_cell_size_mm: value.lod0_cell_size_mm,
         }
     }
 }
@@ -233,7 +266,7 @@ impl PlanetFrame {
             origin_words: self.origin_lod0_cell.map(split_i64),
             frame_index_words: split_u64(self.frame_index),
             camera_relative_m: self.camera_relative_m().map(|value| value as f32),
-            lod0_cell_size_m: LOD0_CELL_SIZE_METERS as f32,
+            lod0_cell_size_m: self.camera.lod0_cell_size_m() as f32,
             page_edge_cells: PAGE_EDGE_CELLS as u32,
         }
     }
@@ -301,10 +334,21 @@ impl PlanetFramePayload {
 pub enum PositionError {
     #[error("planet position contains a non-finite value")]
     NonFinite,
-    #[error("planet position sub-cell remainder must be in [0, 0.1) meters")]
+    #[error("planet position sub-cell remainder must be within its LOD0 cell")]
     SubcellOutOfRange,
+    #[error("planet LOD0 cell size must be non-zero")]
+    InvalidCellSize,
+    #[error("planet positions use different LOD0 cell sizes")]
+    ScaleMismatch,
     #[error("planet position coordinate arithmetic overflowed")]
     CoordinateOverflow,
+}
+
+fn cell_size_meters(lod0_cell_size_mm: u32) -> Result<f64, PositionError> {
+    if lod0_cell_size_mm == 0 {
+        return Err(PositionError::InvalidCellSize);
+    }
+    Ok(f64::from(lod0_cell_size_mm) / 1_000.0)
 }
 
 const fn split_u64(value: u64) -> [u32; 2] {
@@ -625,18 +669,18 @@ mod tests {
 
     #[test]
     fn position_serde_is_canonical_and_rejects_invalid_payloads() {
-        let position = PlanetPosition::new([-63_710_001, 7, -1], [0.099, 0.0, -0.0]).unwrap();
+        let position = PlanetPosition::new([-63_710_001, 7, -1], [0.099, 0.0, -0.0], 100).unwrap();
         let json = serde_json::to_string(&position).unwrap();
         assert_eq!(
             json,
-            r#"{"lod0_cell":[-63710001,7,-1],"subcell_m":[0.099,0.0,0.0]}"#
+            r#"{"lod0_cell":[-63710001,7,-1],"subcell_m":[0.099,0.0,0.0],"lod0_cell_size_mm":100}"#
         );
         assert_eq!(
             serde_json::from_str::<PlanetPosition>(&json).unwrap(),
             position
         );
         assert!(serde_json::from_str::<PlanetPosition>(
-            r#"{"lod0_cell":[0,0,0],"subcell_m":[0.1,0.0,0.0]}"#
+            r#"{"lod0_cell":[0,0,0],"subcell_m":[0.1,0.0,0.0],"lod0_cell_size_mm":100}"#
         )
         .is_err());
         assert!(serde_json::from_str::<PlanetPosition>(
@@ -647,7 +691,7 @@ mod tests {
 
     #[test]
     fn negative_meter_coordinates_use_euclidean_cells() {
-        let position = PlanetPosition::from_meters([-0.001, -0.1, -3.201]).unwrap();
+        let position = PlanetPosition::from_meters([-0.001, -0.1, -3.201], 100).unwrap();
         assert_eq!(position.lod0_cell(), [-1, -1, -33]);
         let expected = [0.099, 0.0, 0.099];
         for (actual, expected) in position.subcell_m().into_iter().zip(expected) {
@@ -656,11 +700,29 @@ mod tests {
     }
 
     #[test]
+    fn positions_from_different_planet_scales_cannot_be_mixed() {
+        let smooth = PlanetPosition::from_meters([1.0, 2.0, 3.0], 1_000).unwrap();
+        let cubic = PlanetPosition::from_meters([1.0, 2.0, 3.0], 100).unwrap();
+
+        assert_eq!(smooth.lod0_cell(), [1, 2, 3]);
+        assert_eq!(cubic.lod0_cell(), [10, 20, 30]);
+        assert_eq!(
+            smooth.relative_meters(cubic),
+            Err(PositionError::ScaleMismatch)
+        );
+        assert_eq!(
+            PlanetPosition::from_lod0_cell([0; 3], 0),
+            Err(PositionError::InvalidCellSize)
+        );
+    }
+
+    #[test]
     fn earth_ground_orbit_and_antipode_frames_stay_canonical() {
         let earth_cells = 63_710_000_i64;
-        let ground = PlanetPosition::new([earth_cells, 0, 0], [0.001, 0.099, 0.05]).unwrap();
-        let orbit = PlanetPosition::new([67_710_000, 0, 0], [0.001, 0.099, 0.05]).unwrap();
-        let antipode = PlanetPosition::new([-earth_cells, 0, 0], [0.001, 0.099, 0.05]).unwrap();
+        let ground = PlanetPosition::new([earth_cells, 0, 0], [0.001, 0.099, 0.05], 100).unwrap();
+        let orbit = PlanetPosition::new([67_710_000, 0, 0], [0.001, 0.099, 0.05], 100).unwrap();
+        let antipode =
+            PlanetPosition::new([-earth_cells, 0, 0], [0.001, 0.099, 0.05], 100).unwrap();
         assert_eq!(
             orbit.relative_meters(ground).unwrap(),
             [400_000.0, 0.0, 0.0]
@@ -691,7 +753,7 @@ mod tests {
         ] {
             let frame = PlanetFrame::new(
                 PlanetId([8; 16]),
-                PlanetPosition::from_lod0_cell(camera_cell),
+                PlanetPosition::from_lod0_cell(camera_cell, 100).unwrap(),
                 u64::MAX,
             );
             let payload = frame.renderer_payload();
@@ -704,16 +766,18 @@ mod tests {
     fn renderer_payload_stays_within_one_millimeter_across_a_rebase() {
         let earth_cells = 63_710_000_i64;
         for camera_cell in [earth_cells + 31, earth_cells + 32] {
-            let camera = PlanetPosition::new([camera_cell, -1, 7], [0.037, 0.081, 0.019]).unwrap();
+            let camera =
+                PlanetPosition::new([camera_cell, -1, 7], [0.037, 0.081, 0.019], 100).unwrap();
             let point = PlanetPosition::new(
                 [
                     camera_cell
-                        + (MILLIMETER_INTERACTION_RADIUS_METERS / LOD0_CELL_SIZE_METERS) as i64
+                        + (MILLIMETER_INTERACTION_RADIUS_METERS / camera.lod0_cell_size_m()) as i64
                         - 1,
                     -4,
                     9,
                 ],
                 [0.092, 0.006, 0.071],
+                100,
             )
             .unwrap();
             let frame = PlanetFrame::new(PlanetId([2; 16]), camera, 5);
@@ -724,15 +788,15 @@ mod tests {
             let camera_relative = payload.camera_relative_m();
             let reconstructed = [
                 ((point.lod0_cell()[0] - origin[0]) as f32
-                    + (subcell[0] / LOD0_CELL_SIZE_METERS) as f32)
+                    + (subcell[0] / point.lod0_cell_size_m()) as f32)
                     * payload.lod0_cell_size_m()
                     - camera_relative[0],
                 ((point.lod0_cell()[1] - origin[1]) as f32
-                    + (subcell[1] / LOD0_CELL_SIZE_METERS) as f32)
+                    + (subcell[1] / point.lod0_cell_size_m()) as f32)
                     * payload.lod0_cell_size_m()
                     - camera_relative[1],
                 ((point.lod0_cell()[2] - origin[2]) as f32
-                    + (subcell[2] / LOD0_CELL_SIZE_METERS) as f32)
+                    + (subcell[2] / point.lod0_cell_size_m()) as f32)
                     * payload.lod0_cell_size_m()
                     - camera_relative[2],
             ];

--- a/crates/subsystems/pulsar_terrain/tests/core_contract.rs
+++ b/crates/subsystems/pulsar_terrain/tests/core_contract.rs
@@ -1,14 +1,10 @@
 use pulsar_terrain::{
-    CellWord, DeterministicGenerator, EditLog, EditMode, EditOp, EditShape, FixedSphereGenerator,
-    NodeState, PageKey, PlanetId, SparseBrickTree, TerrainCore, VoxelPage,
+    CellWord, DeterministicGenerator, EditLog, EditMode, EditOp, EditShape, NodeState, PageKey,
+    PlanetId, PlanetSdfGenerator, SparseBrickTree, TerrainCore, VoxelPage,
 };
 
-fn sphere() -> FixedSphereGenerator {
-    FixedSphereGenerator {
-        center_cell: [0; 3],
-        radius_cells: 64,
-        material: 2,
-    }
+fn sphere() -> PlanetSdfGenerator {
+    PlanetSdfGenerator::zero_relief_test_fixture([0; 3], 64, 2)
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- replace the production fixed-sphere terrain authority with a deterministic, pole-free 3D SDF sampled in Cartesian planet space
- make surface relief, overhangs, and caves part of the canonical field and its content hash
- carry an explicit per-planet LOD0 sample scale through positions, planning, rendering payloads, runtime, and persistence
- use a 1 m default for the smooth planet while preserving the separate exact 10 cm cubic-voxel scale
- make the SDF generator authoritative for runtime page builds, planning captures, persistence restore, and performance benchmarks
- remove the old fixed-sphere generator and planner API completely; isolation tests use the same SDF generator with zero-relief parameters

## Why

A real-scale destructible planet cannot use a planar renderer fixture or a surface-only spherical shell as authority. The sparse hierarchy needs one canonical volumetric scalar field so caves, overhangs, edits, persistence, and later physics all observe the same terrain.

## Validation

- `cargo test -p pulsar_terrain` — 128 unit tests and 6 integration tests pass
- `cargo check -p pulsar_terrain --all-targets`
- `cargo clippy -p pulsar_terrain --all-targets -- -D warnings`
- deterministic SDF identity, relief/cave presence, conservative signed-page summaries, physical scale equivalence, and cross-scale rejection have direct tests

## Status

Draft. The canonical CPU/runtime path is ready for renderer integration, but the planet milestone still requires live visual validation and the documented crack, residency, refinement-latency, destruction, persistence, physics, and performance gates.

Closes #576