### PR TITLE
Properties panel: subscribe to World changes instead of polling every…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8902,7 +8902,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=de0e524e01789003fc0108f18239d7a6575f269f#de0e524e01789003fc0108f18239d7a6575f269f"
+source = "git+https://github.com/Far-Beyond-Pulsar//SceneDB?rev=c761890789b3e3c16b362a91769570bd587e5ac6#c761890789b3e3c16b362a91769570bd587e5ac6"
 dependencies = [
  "ahash 0.8.12",
  "profiling 0.1.0",
@@ -8916,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb_derive"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=de0e524e01789003fc0108f18239d7a6575f269f#de0e524e01789003fc0108f18239d7a6575f269f"
+source = "git+https://github.com/Far-Beyond-Pulsar//SceneDB?rev=c761890789b3e3c16b362a91769570bd587e5ac6#c761890789b3e3c16b362a91769570bd587e5ac6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ window_manager                     = { path = "crates/core/window_manager" }
 pulsar_game                        = { path = "crates/core/pulsar_game" }
 pulsar_core                        = { path = "crates/core/pulsar_core" }
 pulsar_pie_abi                     = { path = "crates/core/pulsar_pie_abi" }
-pulsar_scenedb                     = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "de0e524e01789003fc0108f18239d7a6575f269f", features = ["gpu"] }
+pulsar_scenedb                     = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "c761890789b3e3c16b362a91769570bd587e5ac6", features = ["gpu"] }
 pulsar_reflection                  = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection", rev = "745ee787cc63288463c170aafb778672db8e85ac" }
 pulsar_events                      = { path = "crates/core/pulsar_events" }
 engine_class_derive                = { path = "crates/core/engine_class_derive" }
@@ -327,3 +327,15 @@ wgsl_std = { path = "crates/third-party/psgc/crates/wgsl_std" }
 [patch."https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection"]
 pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "745ee787cc63288463c170aafb778672db8e85ac" }
 pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "745ee787cc63288463c170aafb778672db8e85ac" }
+
+# SceneDB's World-level subscription system (SceneDB#47, merged at c761890)
+# is what the properties panel's cache-until-signaled rework
+# (Pulsar-Native#575) consumes. Patched -- not merely pinned -- because the
+# Helio git dep / submodule still pins an older SceneDB rev internally; a
+# second, differing `pulsar_scenedb` in the graph would split the
+# `World`/`ComponentId` types exchanged across the Helio seam. Same shape as
+# the Pulsar-Reflection patches above (including the `//` URL spelling,
+# which is what lets a patch point at a different rev of the "same" source).
+# Drop this section once Helio repins.
+[patch."https://github.com/Far-Beyond-Pulsar/SceneDB"]
+pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar//SceneDB", rev = "c761890789b3e3c16b362a91769570bd587e5ac6" }

--- a/crates/core/pulsar_world_registry/src/lib.rs
+++ b/crates/core/pulsar_world_registry/src/lib.rs
@@ -204,6 +204,18 @@ fn find_by_component_id(component_type: ComponentId) -> Option<&'static WorldCom
         .find(|r| (r.component_type)() == component_type)
 }
 
+/// Resolve a registered class's `pulsar_scenedb::ComponentId` -- the erased
+/// identity `World` subscriptions are keyed by (SceneDB#47's
+/// `World::subscribe_id`). This is the subscribe-path counterpart to
+/// [`find_by_component_id`] (the drain-path lookup): an editor caller that
+/// only knows a class NAME (the properties panel's reflection metadata) can
+/// arm a subscription without ever naming the Rust type. Returns `None` for
+/// classes not registered here -- those have no live `World` representation,
+/// so there is nothing to subscribe to.
+pub fn component_id_for_class(class_name: &str) -> Option<ComponentId> {
+    find(class_name).map(|r| (r.component_type)())
+}
+
 /// Hydrate `class_name`'s typed component from `data` onto `entity`. Returns
 /// `Ok(false)` if `class_name` isn't registered here (not migrated yet, or
 /// not a real component class) -- not an error, it just means the JSON

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -290,6 +290,70 @@ impl SceneDatabase {
         std::mem::take(&mut *self.property_changes.lock())
     }
 
+    // ── World subscriptions (Pulsar-Native#575, SceneDB#47) ────────────────
+
+    /// Store-swap generation the current `World` belongs to. Subscriptions
+    /// live inside the `World` itself, so [`Self::restore_history_snapshot`]
+    /// (undo/redo -- the one wholesale `*self.store.write() = new_store`
+    /// site, whose epoch bump this reads straight out of `RevisionTracker`)
+    /// silently kills every outstanding [`pulsar_scenedb::SubscriptionId`].
+    /// A subscriber that caches snapshots against subscriptions MUST compare
+    /// this value per frame and re-arm from scratch when it moves; within a
+    /// stable epoch subscriptions stay valid forever (or until their entity
+    /// despawns).
+    pub fn subscriptions_epoch(&self) -> u64 {
+        self.revision_tracker
+            .epoch
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Arm a World-level change subscription for `(object_id, class_name)`'s
+    /// live component -- the properties panel's subscribe-once-per-card
+    /// replacement for poll-every-render. The returned
+    /// [`pulsar_scenedb::SubscriptionId`] is what
+    /// [`Self::take_world_component_events`] events are tagged with; drop it
+    /// with [`Self::unsubscribe_component`] when the card unmounts.
+    ///
+    /// `None` when `class_name` has no `World`-registered component id (the
+    /// legacy JSON-only classes), the object has no live entity yet, or the
+    /// entity is dead -- all "nothing to subscribe to", not errors; callers
+    /// keep polling those cards exactly as they did before.
+    pub fn subscribe_component(
+        &self,
+        object_id: &ObjectId,
+        class_name: &str,
+    ) -> Option<pulsar_scenedb::SubscriptionId> {
+        let cid = pulsar_world_registry::component_id_for_class(class_name)?;
+        let mut store = self.store.write();
+        let entity = store.entity_for(object_id)?;
+        store.world_mut().subscribe_id(entity, cid)
+    }
+
+    /// Disarm a previously armed subscription. Idempotent no-op if it is
+    /// already gone (unsubscribed, or its whole `World` was swapped out from
+    /// under it by undo/redo).
+    pub fn unsubscribe_component(&self, sub: pulsar_scenedb::SubscriptionId) {
+        self.store.write().world_mut().unsubscribe(sub);
+    }
+
+    /// Drain every pending World component-change event (SceneDB#47's
+    /// batched delivery). Call once per frame at your frame boundary --
+    /// between drains the queue accumulates, bounded by SceneDB's own cap.
+    ///
+    /// SINGLE-DRAINER CONTRACT: like [`Self::drain_property_changes`], this
+    /// empties a shared queue -- today exactly one consumer per frame does
+    /// the draining and routes to whoever asked (the properties panel's
+    /// component-card host). If a second live-UI subscriber ever appears,
+    /// this needs to grow per-consumer fanout before both can coexist;
+    /// events discarded by the wrong drainer would strand the other
+    /// consumer's cache stale until something else touched it.
+    pub fn take_world_component_events(&self) -> Vec<pulsar_scenedb::ComponentChangeEvent> {
+        self.store
+            .write()
+            .world_mut()
+            .take_component_change_events()
+    }
+
     /// Record that a specific property was written.  Called from every
     /// mutating method that touches a component property.
     fn record_property_change(&self, object_id: &str, class_name: &str, prop_name: &str) {
@@ -2384,4 +2448,105 @@ mod world_component_hydration_tests {
             .is_some());
     }
 
+    // ── World subscriptions (Pulsar-Native#575, SceneDB#47) ────────────────
+
+    /// The properties panel's core contract: arm once per card, edit the
+    /// live value through the real write path, and the subscription delivers
+    /// exactly one event tagged with that card's id. A drain empties; an
+    /// unsubscribed card hears nothing further.
+    #[test]
+    fn subscribe_component_delivers_events_for_live_edits_to_that_card_only() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+        db.add_component(
+            &id,
+            "StaticMeshComponent".to_string(),
+            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+        );
+
+        let sub = db
+            .subscribe_component(&id, "StaticMeshComponent")
+            .expect("registered class with a live entity subscribes");
+        assert!(
+            db.take_world_component_events().is_empty(),
+            "arming alone must deliver nothing"
+        );
+        // Drain is emptying, not peeking: a second drain is empty too.
+        assert!(db.take_world_component_events().is_empty());
+
+        // Real mutation through the same typed path the panel's setter
+        // closures ride (World::get_mut -> Mut guard -> into_inner).
+        {
+            let mut store = db.store.write();
+            let entity = store.entity_for(&id).unwrap();
+            let instance = pulsar_world_registry::get_world_component_as_engine_class_mut(
+                "StaticMeshComponent",
+                store.world_mut(),
+                entity,
+            )
+            .unwrap();
+            let concrete = instance
+                .as_any_mut()
+                .downcast_mut::<StaticMeshComponent>()
+                .unwrap();
+            concrete.mesh_asset = "meshes/primitives/SM_Sphere.fbx".into();
+        }
+
+        let events: Vec<_> = db
+            .take_world_component_events()
+            .into_iter()
+            .filter(|e| e.subscription == sub)
+            .collect();
+        assert_eq!(events.len(), 1, "one real mutation = exactly one event");
+        assert_eq!(events[0].kind, pulsar_scenedb::ComponentChangeKind::Mutated);
+        assert!(db.take_world_component_events().is_empty());
+
+        // After unsubscribe, the same kind of write stays silent.
+        db.unsubscribe_component(sub);
+        {
+            let mut store = db.store.write();
+            let entity = store.entity_for(&id).unwrap();
+            let instance = pulsar_world_registry::get_world_component_as_engine_class_mut(
+                "StaticMeshComponent",
+                store.world_mut(),
+                entity,
+            )
+            .unwrap();
+            let concrete = instance
+                .as_any_mut()
+                .downcast_mut::<StaticMeshComponent>()
+                .unwrap();
+            concrete.mesh_asset = "meshes/primitives/SM_Cone.fbx".into();
+        }
+        assert!(db.take_world_component_events().is_empty());
+    }
+
+    /// Unregistered classes have no live `World` representation -- there is
+    /// nothing to subscribe to, and `None` (not an error) is the answer.
+    #[test]
+    fn subscribing_an_unregistered_class_is_none() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+        assert!(db.subscribe_component(&id, "NoSuchComponentClass").is_none());
+    }
+
+    /// Undo/redo swaps the whole `World` out from under any outstanding
+    /// subscriptions (they live inside it) without firing events. The epoch
+    /// is the only signal that this happened, so it MUST advance across a
+    /// restore even when the snapshot content is identical.
+    #[test]
+    fn restore_history_snapshot_bumps_the_subscriptions_epoch() {
+        let db = SceneDatabase::new();
+        let id = db.add_object(object("Cube"), None);
+
+        let before = db.subscriptions_epoch();
+        let snapshot = db.capture_history_snapshot();
+
+        db.restore_history_snapshot(&snapshot).unwrap();
+        assert_ne!(
+            db.subscriptions_epoch(),
+            before,
+            "a store swap must invalidate every outstanding subscription"
+        );
+    }
 }

--- a/crates/editor/ui_level_editor/src/level_editor/ui/properties/object_type_fields/mod.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/ui/properties/object_type_fields/mod.rs
@@ -14,7 +14,9 @@
 use engine_backend::scene::ComponentInstance;
 use gpui::{prelude::*, *};
 use pulsar_reflection::{PropertyMetadata, REGISTRY, RUNTIME_TYPE_REGISTRY};
+use pulsar_scenedb::SubscriptionId;
 use serde_json::Value;
+use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use ui::button::ButtonVariants as _;
@@ -66,6 +68,37 @@ pub struct ObjectTypeFieldsSection {
     /// Number of components from the last render — used to detect structural
     /// changes without calling `get_components()` (which clones JSON).
     pub(super) cached_component_count: usize,
+
+    // ── Live-value subscription caches (Pulsar-Native#575, SceneDB#47) ────
+    //
+    // Before subscriptions existed, every render pass re-pulled every
+    // property of every mounted card straight from `World`, unconditionally,
+    // because nothing could say whether the underlying data had moved. Now:
+    // each mounted card arms ONE World subscription (per `(entity, class)`
+    // pair), keeps its latest pulled values here, and re-pulls only when a
+    // signal fires -- a subscription event for its own card, a legacy JSON-
+    // path write recorded in the property change set, or a structural /
+    // store-swap invalidation.
+    /// Latest known live values per mounted component card, keyed by class
+    /// name. Borrowed during row building, never consumed -- rows only read.
+    pub(super) world_value_cache: HashMap<String, Vec<Box<dyn Any>>>,
+    /// Classes whose cached values are stale and must be re-pulled on the
+    /// next render pass.
+    pub(super) dirty_classes: HashSet<String>,
+    /// Armed World subscriptions per mounted card (`class -> SubscriptionId`).
+    /// Events arrive tagged with this id; this map is also what `Drop` uses
+    /// to disarm everything when the section is torn down (selection change).
+    pub(super) world_subs: HashMap<String, SubscriptionId>,
+    /// Classes with no `World`-registered component id at all (the legacy
+    /// JSON-only classes). Permanently un-subscribable until the card set
+    /// structurally changes; remembered so the registry lookup isn't paid
+    /// every render for a card that can never have a live value.
+    pub(super) unsubscribable_classes: HashSet<String>,
+    /// Store-generation (`SceneDatabase::subscriptions_epoch`) these
+    /// subscriptions were armed in. Undo/redo swaps the whole `World`,
+    /// killing every outstanding subscription without any event ever firing;
+    /// an epoch mismatch means drop everything and re-arm from scratch.
+    pub(super) subs_epoch: u64,
 }
 
 impl ObjectTypeFieldsSection {
@@ -131,7 +164,33 @@ impl ObjectTypeFieldsSection {
             expanded_property_categories: HashSet::new(),
             property_metadata_cache: HashMap::new(),
             cached_component_count: 0,
+            world_value_cache: HashMap::new(),
+            dirty_classes: HashSet::new(),
+            world_subs: HashMap::new(),
+            unsubscribable_classes: HashSet::new(),
+            subs_epoch: 0, // corrected against the live epoch on first render
         }
+    }
+
+    /// Disarm every World subscription this section armed. Called from
+    /// `Drop` (section teardown on selection change) and from the
+    /// structural/store-swap invalidation paths.
+    fn release_world_subscriptions(&mut self) {
+        for (_, sub) in self.world_subs.drain() {
+            self.scene_db.unsubscribe_component(sub);
+        }
+    }
+
+    /// Invalidate ALL per-card subscription state -- next render re-arms and
+    /// re-pulls everything. For undo/redo's wholesale `World` swap (whose
+    /// outstanding subscriptions die silently, no events) and structural
+    /// card-set changes.
+    fn reset_world_subscription_state(&mut self) {
+        self.release_world_subscriptions();
+        self.world_value_cache.clear();
+        self.dirty_classes.clear();
+        self.unsubscribable_classes.clear();
+        self.subs_epoch = self.scene_db.subscriptions_epoch();
     }
 
     fn add_component(
@@ -210,6 +269,15 @@ impl ObjectTypeFieldsSection {
     }
 }
 
+impl Drop for ObjectTypeFieldsSection {
+    fn drop(&mut self) {
+        // Selection changed / panel closed: stop watching this object's
+        // components so a long-lived editor doesn't accumulate dead
+        // subscriptions for every object that was ever inspected.
+        self.release_world_subscriptions();
+    }
+}
+
 impl Render for ObjectTypeFieldsSection {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         use super::ComponentHierarchyPanel;
@@ -231,6 +299,18 @@ impl Render for ObjectTypeFieldsSection {
         // entries from removed/renamed components don't persist.
         if structural || count_changed {
             self.property_metadata_cache.clear();
+            // The card set itself changed: every subscription/cache entry is
+            // suspect (a removed card's sub must be disarmed; a re-added one
+            // needs a fresh arm against the possibly-new entity).
+            self.reset_world_subscription_state();
+        }
+
+        // Undo/redo swapped the whole `World` out from under us: every
+        // outstanding subscription died without an event ever firing. The
+        // epoch check is the only signal -- see
+        // `SceneDatabase::subscriptions_epoch`.
+        if self.subs_epoch != self.scene_db.subscriptions_epoch() {
+            self.reset_world_subscription_state();
         }
 
         // ── Object icon picker row ─────────────────────────────────────────
@@ -271,8 +351,49 @@ impl Render for ObjectTypeFieldsSection {
         let diag_card = self.render_diag_card(&attached, cx);
 
         // ── Per-component property cards ───────────────────────────────────
+        //
+        // Mark cards dirty from the two signals that can have fired since
+        // last render, BEFORE building them:
+        //
+        // 1. World subscription events (SceneDB#47) -- the push signal for
+        //    every World-registered card: real inserts/mutations/removals of
+        //    exactly the `(entity, component)` pairs these cards display,
+        //    whether the write came from this panel, an AI tool, or a
+        //    renderer-side sync. Events are matched back to their card by
+        //    SubscriptionId.
+        // 2. The legacy JSON change set -- covers the handful of
+        //    not-World-registered classes whose only write path still goes
+        //    through `metadata_db` (they can never fire a World event).
+        //
+        // SINGLE-DRAINER CONTRACT: `take_world_component_events` empties a
+        // queue shared by every subscriber in the process; this section is
+        // the one consumer today. See
+        // `SceneDatabase::take_world_component_events`'s doc before adding a
+        // second drainer.
+        //
+        // Guarded on having armed at least one subscription: draining takes
+        // the store's WRITE lock, and an all-legacy-cards panel (nothing
+        // subscribable) must not pay that on every render pass. SceneDB's
+        // own cap bounds the undrained queue meanwhile.
+        if !self.world_subs.is_empty() {
+            for event in self.scene_db.take_world_component_events() {
+                for (class, sub) in &self.world_subs {
+                    if *sub == event.subscription {
+                        self.dirty_classes.insert(class.clone());
+                    }
+                }
+            }
+        }
+        if !property_changes.is_empty() {
+            for comp in &attached {
+                if property_changes.class_changed(&self.object_id, &comp.class_name) {
+                    self.dirty_classes.insert(comp.class_name.clone());
+                }
+            }
+        }
+
         let component_sections =
-            self.render_component_sections(&attached, &property_changes, window, cx);
+            self.render_component_sections(&attached, window, cx);
 
         v_flex()
             .w_full()

--- a/crates/editor/ui_level_editor/src/level_editor/ui/properties/object_type_fields/property_renderer.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/ui/properties/object_type_fields/property_renderer.rs
@@ -2,7 +2,11 @@
 //!
 //! For each [`ComponentInstance`] attached to the selected object, this module:
 //!   1. Looks up cached property metadata (populated lazily, reused across frames).
-//!   2. Reads current values from the scene database.
+//!   2. Serves current values from the section's per-card snapshot cache,
+//!      re-pulling from the live World only when a signal fired for that
+//!      specific card since the last render (Pulsar-Native#575): its own
+//!      World subscription event, a legacy JSON-path write, or a
+//!      structural/epoch invalidation.
 //!   3. Delegates row rendering to [`ui_common::render_property_row_runtime`],
 //!      which picks the editor registered for each property's type.
 //!   4. Groups rows into collapsible category sections via [`category_section`].
@@ -10,9 +14,12 @@
 //! Performance notes:
 //! - The metadata cache eliminates the per-frame `create_instance()` +
 //!   `get_properties()` allocation — previously the single biggest cost.
-//! - `with_world_component` holds one `store.read()` per component,
-//!   reading all property values inside that lock instead of acquiring
-//!   a separate lock per property.
+//! - The value snapshot cache eliminates the per-render World re-pull that
+//!   used to run unconditionally for every visible property on every pass;
+//!   a clean render performs zero World reads. A fresh pull holds one
+//!   `store.read()` per component (`with_world_component`), reading all
+//!   property values inside that lock instead of one acquisition per
+//!   property.
 
 use engine_backend::scene::ComponentInstance;
 use gpui::{prelude::*, *};
@@ -22,7 +29,6 @@ use std::sync::Arc;
 use ui::{h_flex, v_flex, ActiveTheme, Icon, IconName, Sizable};
 
 use crate::level_editor::core::commands::{execute_command, SceneCommand};
-use crate::level_editor::core::scene_database::PropertyChangeSet;
 use super::category_section::group_rows_by_category;
 use super::{ObjectTypeFieldsSection, PropertyMetadataCacheEntry};
 
@@ -53,6 +59,36 @@ fn read_property_from_world(
         .unwrap_or_else(|| (prop.getter)(default_instance))
 }
 
+/// Pull a card's full value snapshot fresh from the live sources: one
+/// batched `World` read when the entity/component is hydrated, otherwise
+/// per-property fallback reads (live miss → JSON → default instance). This
+/// is the only place a clean render still touches `World` — every other
+/// render serves from [`ObjectTypeFieldsSection::world_value_cache`].
+fn read_card_values_fresh(
+    scene_db: &crate::level_editor::scene_database::SceneDatabase,
+    object_id: &crate::level_editor::scene_database::ObjectId,
+    class_name: &str,
+    properties: &[PropertyMetadata],
+    component: &ComponentInstance,
+    default_instance: &dyn pulsar_reflection::EngineClass,
+) -> Vec<Box<dyn Any>> {
+    let batch = scene_db.with_world_component(object_id, class_name, |instance| {
+        properties
+            .iter()
+            .map(|prop| (prop.getter)(instance))
+            .collect::<Vec<_>>()
+    });
+    match batch {
+        Some(values) => values,
+        None => properties
+            .iter()
+            .map(|prop| {
+                read_property_from_world(scene_db, object_id, class_name, prop, component, default_instance)
+            })
+            .collect(),
+    }
+}
+
 impl ObjectTypeFieldsSection {
     /// Ensure the metadata cache is populated for `class_name`.
     fn ensure_metadata_cached(&mut self, class_name: &str) -> Option<()> {
@@ -80,14 +116,19 @@ impl ObjectTypeFieldsSection {
     /// Components whose class is not in the registry are silently skipped — the
     /// diagnostic banner in [`super`] already surfaces that condition.
     ///
-    /// ## Performance
-    /// Uses `with_world_component` to read ALL property values of a component
-    /// under a single `store.read()` acquisition (one RwLock READ per component
-    /// instead of one per property).
+    /// ## Performance (Pulsar-Native#575: subscribe, don't poll)
+    ///
+    /// Property VALUES come from the per-card snapshot cache (the section's
+    /// `world_value_cache`) and are only re-pulled from `World` when a signal
+    /// actually fired for that specific card -- its own World subscription
+    /// event, a legacy JSON-path write, or a structural/epoch invalidation.
+    /// An unrelated scene change (a gizmo drag anywhere, any other revision
+    /// bump) re-renders this panel from cached values with zero `World`
+    /// traffic. A fresh pull still happens under ONE `store.read()`
+    /// acquisition per card (`with_world_component`).
     pub(super) fn render_component_sections(
         &mut self,
         attached: &[ComponentInstance],
-        _property_changes: &PropertyChangeSet,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Vec<AnyElement> {
@@ -127,18 +168,48 @@ impl ObjectTypeFieldsSection {
                     .get(class_name.as_str())?
                     ._default_instance;
 
-                // ── Single lock acquisition: read ALL property values ─────
-                // The closure holds `store.read()` for the entire duration
-                // and calls each getter against the live World component.
-                // Values are consumed via `into_iter()` so each `Box<dyn Any>`
-                // is used exactly once — no Clone needed.
-                let batch_values: Option<Vec<Box<dyn Any>>> =
-                    scene_db.with_world_component(&object_id, class_name, |instance| {
-                        properties
-                            .iter()
-                            .map(|prop| (prop.getter)(instance))
-                            .collect()
-                    });
+                // ── Cache-until-signaled value fetch (Pulsar-Native#575) ──
+                //
+                // Clean card + cached snapshot: lend the cached values to the
+                // row builder below, zero `World` traffic. Dirty or never-
+                // pulled card: arm its World subscription (once per mounted
+                // card) and pull fresh values.
+                let card_dirty = self.dirty_classes.remove(class_name.as_str());
+                let mut values = if card_dirty {
+                    None
+                } else {
+                    // Take out of the cache rather than borrow: the row loop
+                    // below needs `&mut self` for widget state, and the vec
+                    // goes straight back in afterwards.
+                    self.world_value_cache.remove(class_name.as_str())
+                };
+                if values.is_none() {
+                    // Arm once per mounted card. Classes with no World
+                    // registration are remembered as permanently
+                    // un-subscribable (they ride the legacy JSON fallback
+                    // forever); a live-entity miss is NOT remembered -- the
+                    // entity may hydrate any moment, so retry next render.
+                    if !self.world_subs.contains_key(class_name.as_str())
+                        && !self.unsubscribable_classes.contains(class_name.as_str())
+                    {
+                        if pulsar_world_registry::component_id_for_class(class_name).is_none() {
+                            self.unsubscribable_classes.insert(class_name.clone());
+                        } else if let Some(sub) =
+                            scene_db.subscribe_component(&object_id, class_name)
+                        {
+                            self.world_subs.insert(class_name.clone(), sub);
+                        }
+                    }
+                    values = Some(read_card_values_fresh(
+                        &scene_db,
+                        &object_id,
+                        class_name,
+                        &properties,
+                        component,
+                        default_inst,
+                    ));
+                }
+                let values = values.expect("fresh pull or cache hit fills this");
 
                 let mut row_data: Vec<(
                     AnyElement,
@@ -148,109 +219,58 @@ impl ObjectTypeFieldsSection {
                     Option<usize>,
                 )> = Vec::new();
 
-                if let Some(values) = batch_values {
-                    // Batch succeeded — consume values via into_iter().
-                    for (prop, value) in properties.iter().zip(values.into_iter()) {
-                        let write_back = {
-                            let state_arc = self.state_arc.clone();
-                            let oid = object_id.clone();
-                            let cls = class_name.clone();
-                            let pn = prop.name.to_string();
-                            Arc::new(
-                                move |new_val: Box<dyn Any + Send>,
-                                      _window: &mut Window,
-                                      _cx: &mut App| {
-                                    execute_command(
-                                        &mut state_arc.write(),
-                                        SceneCommand::SetComponentProperty {
-                                            id: oid.clone(),
-                                            class_name: cls.clone(),
-                                            prop_name: pn.clone(),
-                                            value: new_val,
-                                        },
-                                    );
-                                },
-                            )
-                        };
+                // One unified row loop: `values` is the card's live snapshot
+                // (fresh pull or cache hit -- indistinguishable from here
+                // on). Borrowed, not consumed; it goes back into the cache
+                // right after this loop.
+                for (prop, value) in properties.iter().zip(values.iter()) {
+                    let write_back = {
+                        let state_arc = self.state_arc.clone();
+                        let oid = object_id.clone();
+                        let cls = class_name.clone();
+                        let pn = prop.name.to_string();
+                        Arc::new(
+                            move |new_val: Box<dyn Any + Send>,
+                                  _window: &mut Window,
+                                  _cx: &mut App| {
+                                execute_command(
+                                    &mut state_arc.write(),
+                                    SceneCommand::SetComponentProperty {
+                                        id: oid.clone(),
+                                        class_name: cls.clone(),
+                                        prop_name: pn.clone(),
+                                        value: new_val,
+                                    },
+                                );
+                            },
+                        )
+                    };
 
-                        let row = ui_common::render_property_row_runtime(
-                            &mut self.property_state,
-                            "level",
-                            class_name,
-                            &prop.display_name,
-                            prop.name,
-                            prop.type_info,
-                            value.as_ref(),
-                            write_back,
-                            window,
-                            cx,
-                        );
+                    let row = ui_common::render_property_row_runtime(
+                        &mut self.property_state,
+                        "level",
+                        class_name,
+                        &prop.display_name,
+                        prop.name,
+                        prop.type_info,
+                        value.as_ref(),
+                        write_back,
+                        window,
+                        cx,
+                    );
 
-                        row_data.push((
-                            row,
-                            prop.category.map(str::to_string),
-                            prop.category_color.map(str::to_string),
-                            prop.category_default_collapsed,
-                            prop.category_order,
-                        ));
-                    }
-                } else {
-                    // Batch miss — entity not in World or class not hydrated.
-                    // Fall back to per-property reads (JSON → default).
-                    for prop in properties.iter() {
-                        let current_any = read_property_from_world(
-                            &scene_db,
-                            &object_id,
-                            class_name,
-                            prop,
-                            component,
-                            default_inst,
-                        );
-
-                        let write_back = {
-                            let state_arc = self.state_arc.clone();
-                            let oid = object_id.clone();
-                            let cls = class_name.clone();
-                            let pn = prop.name.to_string();
-                            Arc::new(
-                                move |new_val: Box<dyn Any + Send>,
-                                      _window: &mut Window,
-                                      _cx: &mut App| {
-                                    execute_command(
-                                        &mut state_arc.write(),
-                                        SceneCommand::SetComponentProperty {
-                                            id: oid.clone(),
-                                            class_name: cls.clone(),
-                                            prop_name: pn.clone(),
-                                            value: new_val,
-                                        },
-                                    );
-                                },
-                            )
-                        };
-
-                        let row = ui_common::render_property_row_runtime(
-                            &mut self.property_state,
-                            "level",
-                            class_name,
-                            &prop.display_name,
-                            prop.name,
-                            prop.type_info,
-                            current_any.as_ref(),
-                            write_back,
-                            window,
-                            cx,
-                        );
-
-                        row_data.push((
-                            row,
-                            prop.category.map(str::to_string),
-                            prop.category_color.map(str::to_string),
-                            prop.category_default_collapsed,
-                            prop.category_order,
-                        ));
-                    }
+                    row_data.push((
+                        row,
+                        prop.category.map(str::to_string),
+                        prop.category_color.map(str::to_string),
+                        prop.category_default_collapsed,
+                        prop.category_order,
+                    ));
                 }
+
+                // Hand the snapshot back -- next render lends it out again
+                // unless a signal marked this card dirty.
+                self.world_value_cache.insert(class_name.clone(), values);
 
                 let (mut uncategorized, categorized) = group_rows_by_category(row_data);
                 let category_elements =


### PR DESCRIPTION

Dependency half:
- Bump pulsar_scenedb pin de0e524 -> c761890 (SceneDB#47's World-level per-(Entity, ComponentId) subscription system, merged via SceneDB#50) and add a [patch] section so Helio's older internal pin unifies onto the same crate -- same pattern as the Pulsar-Reflection patches; drop once Helio repins.
- pulsar_world_registry: component_id_for_class() -- the subscribe-path counterpart to the existing ComponentId-keyed removal lookup.

Consumer half (the API #575 asks for):
- SceneDatabase: subscribe_component/unsubscribe_component/ take_world_component_events wrappers + subscriptions_epoch() (RevisionTracker's swap epoch -- undo/redo swaps the whole World and kills outstanding subscriptions silently; the epoch is the only signal).
- ObjectTypeFieldsSection: one subscription per mounted component card, armed once at first pull; per-card value snapshot cache; re-pull only when that card's own signal fires (World event, legacy JSON-path write, structural change, or epoch bump). Drop disarms everything on selection change. An unrelated scene change now re-renders the panel with zero World traffic instead of re-pulling every property of every card.