### PR TITLE
Fix StaticMeshComponent hydration: emit required texture slots in default level + legacy shim

### DIFF
--- a/assets/default.level
+++ b/assets/default.level
@@ -263,7 +263,14 @@
           "index": 2,
           "class_name": "StaticMeshComponent",
           "data": {
-            "mesh_asset": "meshes/primitives/SM_Sphere.fbx"
+            "mesh_asset": "meshes/primitives/SM_Sphere.fbx",
+            "base_color_asset": "",
+            "normal_asset": "",
+            "roughness_metallic_asset": "",
+            "emissive_asset": "",
+            "occlusion_asset": "",
+            "specular_color_asset": "",
+            "specular_weight_asset": ""
           }
         },
         {
@@ -773,7 +780,14 @@
           "index": 0,
           "class_name": "StaticMeshComponent",
           "data": {
-            "mesh_asset": "meshes/primitives/SM_Cube.fbx"
+            "mesh_asset": "meshes/primitives/SM_Cube.fbx",
+            "base_color_asset": "",
+            "normal_asset": "",
+            "roughness_metallic_asset": "",
+            "emissive_asset": "",
+            "occlusion_asset": "",
+            "specular_color_asset": "",
+            "specular_weight_asset": ""
           }
         }
       ]
@@ -814,7 +828,14 @@
           "index": 0,
           "class_name": "StaticMeshComponent",
           "data": {
-            "mesh_asset": "monkey.fbx"
+            "mesh_asset": "monkey.fbx",
+            "base_color_asset": "",
+            "normal_asset": "",
+            "roughness_metallic_asset": "",
+            "emissive_asset": "",
+            "occlusion_asset": "",
+            "specular_color_asset": "",
+            "specular_weight_asset": ""
           }
         }
       ]
@@ -856,7 +877,14 @@
           "index": 0,
           "class_name": "StaticMeshComponent",
           "data": {
-            "mesh_asset": "meshes/primitives/SM_Cube.fbx"
+            "mesh_asset": "meshes/primitives/SM_Cube.fbx",
+            "base_color_asset": "",
+            "normal_asset": "",
+            "roughness_metallic_asset": "",
+            "emissive_asset": "",
+            "occlusion_asset": "",
+            "specular_color_asset": "",
+            "specular_weight_asset": ""
           }
         }
       ]
@@ -897,7 +925,14 @@
           "index": 0,
           "class_name": "StaticMeshComponent",
           "data": {
-            "mesh_asset": "monkey.fbx"
+            "mesh_asset": "monkey.fbx",
+            "base_color_asset": "",
+            "normal_asset": "",
+            "roughness_metallic_asset": "",
+            "emissive_asset": "",
+            "occlusion_asset": "",
+            "specular_color_asset": "",
+            "specular_weight_asset": ""
           }
         }
       ]
@@ -1404,7 +1439,14 @@
           "index": 0,
           "class_name": "StaticMeshComponent",
           "data": {
-            "mesh_asset": "meshes/primitives/SM_Cube.fbx"
+            "mesh_asset": "meshes/primitives/SM_Cube.fbx",
+            "base_color_asset": "",
+            "normal_asset": "",
+            "roughness_metallic_asset": "",
+            "emissive_asset": "",
+            "occlusion_asset": "",
+            "specular_color_asset": "",
+            "specular_weight_asset": ""
           }
         }
       ]
@@ -1417,7 +1459,14 @@
         "class_name": "StaticMeshComponent",
         "enabled": true,
         "data": {
-          "mesh_asset": "monkey.fbx"
+          "mesh_asset": "monkey.fbx",
+          "base_color_asset": "",
+          "normal_asset": "",
+          "roughness_metallic_asset": "",
+          "emissive_asset": "",
+          "occlusion_asset": "",
+          "specular_color_asset": "",
+          "specular_weight_asset": ""
         }
       }
     ],
@@ -1622,7 +1671,14 @@
         "class_name": "StaticMeshComponent",
         "enabled": true,
         "data": {
-          "mesh_asset": "meshes/primitives/SM_Sphere.fbx"
+          "mesh_asset": "meshes/primitives/SM_Sphere.fbx",
+          "base_color_asset": "",
+          "normal_asset": "",
+          "roughness_metallic_asset": "",
+          "emissive_asset": "",
+          "occlusion_asset": "",
+          "specular_color_asset": "",
+          "specular_weight_asset": ""
         }
       },
       {
@@ -1708,7 +1764,14 @@
         "class_name": "StaticMeshComponent",
         "enabled": true,
         "data": {
-          "mesh_asset": "meshes/primitives/SM_Cube.fbx"
+          "mesh_asset": "meshes/primitives/SM_Cube.fbx",
+          "base_color_asset": "",
+          "normal_asset": "",
+          "roughness_metallic_asset": "",
+          "emissive_asset": "",
+          "occlusion_asset": "",
+          "specular_color_asset": "",
+          "specular_weight_asset": ""
         }
       }
     ],
@@ -1821,7 +1884,14 @@
         "class_name": "StaticMeshComponent",
         "enabled": true,
         "data": {
-          "mesh_asset": "meshes/primitives/SM_Cube.fbx"
+          "mesh_asset": "meshes/primitives/SM_Cube.fbx",
+          "base_color_asset": "",
+          "normal_asset": "",
+          "roughness_metallic_asset": "",
+          "emissive_asset": "",
+          "occlusion_asset": "",
+          "specular_color_asset": "",
+          "specular_weight_asset": ""
         }
       }
     ],
@@ -1830,7 +1900,14 @@
         "class_name": "StaticMeshComponent",
         "enabled": true,
         "data": {
-          "mesh_asset": "meshes/primitives/SM_Cube.fbx"
+          "mesh_asset": "meshes/primitives/SM_Cube.fbx",
+          "base_color_asset": "",
+          "normal_asset": "",
+          "roughness_metallic_asset": "",
+          "emissive_asset": "",
+          "occlusion_asset": "",
+          "specular_color_asset": "",
+          "specular_weight_asset": ""
         }
       }
     ],
@@ -2027,7 +2104,14 @@
         "class_name": "StaticMeshComponent",
         "enabled": true,
         "data": {
-          "mesh_asset": "monkey.fbx"
+          "mesh_asset": "monkey.fbx",
+          "base_color_asset": "",
+          "normal_asset": "",
+          "roughness_metallic_asset": "",
+          "emissive_asset": "",
+          "occlusion_asset": "",
+          "specular_color_asset": "",
+          "specular_weight_asset": ""
         }
       }
     ],

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -261,6 +261,24 @@ impl RevisionTracker {
     }
 }
 
+/// A `StaticMeshComponent` data payload carrying every texture slot the
+/// current class requires (Helio#237). Older scenes predate the slots; the
+/// legacy `props.mesh_asset` projection and tests must emit all of them or
+/// hydration's deserialization rejects the instance outright. Empty paths
+/// mean "slot unassigned", which hydrate treats as zero-semantics.
+fn static_mesh_component_json(mesh_asset: &str) -> serde_json::Value {
+    serde_json::json!({
+        "mesh_asset": mesh_asset,
+        "base_color_asset": "",
+        "normal_asset": "",
+        "roughness_metallic_asset": "",
+        "emissive_asset": "",
+        "occlusion_asset": "",
+        "specular_color_asset": "",
+        "specular_weight_asset": ""
+    })
+}
+
 impl SceneDatabase {
     pub fn new() -> Self {
         Self {
@@ -477,7 +495,7 @@ impl SceneDatabase {
                 inline_components.push(ComponentInstance {
                     class_name: "StaticMeshComponent".to_string(),
                     enabled: true,
-                    data: serde_json::json!({ "mesh_asset": mesh_asset }),
+                    data: static_mesh_component_json(mesh_asset),
                 });
             }
         }
@@ -2181,7 +2199,7 @@ mod world_component_hydration_tests {
         db.add_component(
             &id,
             "StaticMeshComponent".to_string(),
-            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+            static_mesh_component_json("meshes/primitives/SM_Cube.fbx"),
         );
 
         let store = db.store.read();
@@ -2197,7 +2215,7 @@ mod world_component_hydration_tests {
         db.add_component(
             &id,
             "StaticMeshComponent".to_string(),
-            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+            static_mesh_component_json("meshes/primitives/SM_Cube.fbx"),
         );
 
         db.update_component_property(
@@ -2220,7 +2238,7 @@ mod world_component_hydration_tests {
         db.add_component(
             &id,
             "StaticMeshComponent".to_string(),
-            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+            static_mesh_component_json("meshes/primitives/SM_Cube.fbx"),
         );
         {
             let store = db.store.read();
@@ -2242,7 +2260,7 @@ mod world_component_hydration_tests {
         db.add_component(
             &id,
             "StaticMeshComponent".to_string(),
-            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+            static_mesh_component_json("meshes/primitives/SM_Cube.fbx"),
         );
 
         db.set_component_enabled(&id, 0, false);
@@ -2720,7 +2738,7 @@ mod world_component_hydration_tests {
         db.add_component(
             &id,
             "StaticMeshComponent".to_string(),
-            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+            static_mesh_component_json("meshes/primitives/SM_Cube.fbx"),
         );
         db.add_component(
             &id,
@@ -2752,7 +2770,7 @@ mod world_component_hydration_tests {
         db.add_component(
             &id,
             "StaticMeshComponent".to_string(),
-            serde_json::json!({"mesh_asset": "meshes/primitives/SM_Cube.fbx"}),
+            static_mesh_component_json("meshes/primitives/SM_Cube.fbx"),
         );
 
         let sub = db


### PR DESCRIPTION
Helio#237 added seven required texture-slot fields to \StaticMeshComponent\ (\ase_color_asset\, \
ormal_asset\, \oughness_metallic_asset\, \missive_asset\, \occlusion_asset\, \specular_color_asset\, \specular_weight_asset\). Scene JSON that predates the slots fails hydration with 'missing field base_color_asset'.

- \ssets/default.level\: all 12 StaticMeshComponent instances now carry every slot (empty = unassigned, zero-semantics per hydrate).
- The legacy \props.mesh_asset\ compatibility projection emits a fully-compliant payload via a shared \static_mesh_component_json\ helper; the world-component hydration test fixtures use it too (20/20 passing).

Note: user scenes saved before Helio#237 that carry inline component_instances will still need this shim or a resave; longer-term serde defaults in helio-component would make the struct itself backward-compatible.