### PR TITLE
Phase 2: GPU ownership boundary — scene_store marker + loud unrouted-misuse errors

### DIFF
--- a/crates/core/engine_class_derive/src/lib.rs
+++ b/crates/core/engine_class_derive/src/lib.rs
@@ -76,6 +76,7 @@ use syn::{
         engine_class_no_register,
         engine_class_serialize,
         engine_class_deserialize,
+        engine_class_scene_store,
         gpu
     )
 )]
@@ -98,6 +99,17 @@ pub fn derive_engine_class(input: TokenStream) -> TokenStream {
     } else {
         quote! { None }
     };
+
+    // GPU ownership boundary signal (see the field-scan comment below): the
+    // attribute macro stamps `#[engine_class_scene_store]` when the
+    // `scene_store` flag routed this struct's GPU storage to SceneDB's own
+    // `#[derive(SceneStore)]`. Same mechanism/limitation as the serialize /
+    // deserialize markers further down -- a derive never sees the derive
+    // list, only these stamped markers.
+    let scene_store_routed = input
+        .attrs
+        .iter()
+        .any(|a| a.path().is_ident("engine_class_scene_store"));
 
     // Extract direct #[property] fields and optional #[sub_props] flattening fields.
     let (property_impls, property_fields, sub_props_fields, gpu_leaf_fields): (
@@ -159,23 +171,50 @@ pub fn derive_engine_class(input: TokenStream) -> TokenStream {
                             field,
                         ));
                     }
-                    // GPU storage is SceneDB's domain, exclusively: a
-                    // `#[gpu]` field's storage shape (packed / var-len /
-                    // heavy) is decided entirely by that struct's own
-                    // `#[derive(pulsar_scenedb::SceneStore)]` -- requested
-                    // via the `scene_store` flag (`StaticMeshComponent`'s
-                    // `vertices`/`indices`, Pulsar-Native#561 Phase D).
-                    // This derive contributes only the packed-scalar
-                    // reflection companion below; it deliberately does not
-                    // classify Vec or GpuHeavy fields (see the engine-class
-                    // GPU de-duplication audit).
-                    if is_gpu && !is_vec_type(&field.ty) {
-                        let field_ident = field.ident.clone().unwrap();
-                        let override_ = match parse_gpu_attr(field) {
-                            Ok(o) => o,
-                            Err(err) => return err.to_compile_error().into(),
-                        };
-                        gpu_fields.push(GpuLeafField { ident: field_ident, field_ty: field.ty.clone(), override_ });
+                    // GPU ownership boundary (engine-class GPU de-duplication
+                    // audit): packed-scalar `#[gpu]` fields are THIS derive's
+                    // only storage concern. Var-len (`Vec<T>`) and heavy
+                    // (`GpuHeavy<T>`) shapes belong exclusively to SceneDB's
+                    // own `#[derive(SceneStore)]` -- a struct declares that
+                    // routing via the `scene_store` flag, which the attribute
+                    // macro stamps as an `#[engine_class_scene_store]` marker
+                    // (the derive can never see the derive list itself).
+                    // Unrouted misuse is a compile error, not silent
+                    // inertness.
+                    if is_gpu {
+                        if is_gpu_heavy_shape(&field.ty) {
+                            if !scene_store_routed {
+                                return syn::Error::new_spanned(
+                                    field,
+                                    "#[gpu] GpuHeavy<T> fields use SceneDB's heavy/handle-split \
+                                     storage, owned by this struct's own \
+                                     #[derive(pulsar_scenedb::SceneStore)] -- add the \
+                                     `scene_store` flag to #[engine_class]. This derive \
+                                     generates packed-scalar companions only.",
+                                )
+                                .to_compile_error()
+                                .into();
+                            }
+                        } else if is_vec_type(&field.ty) {
+                            if !scene_store_routed {
+                                return syn::Error::new_spanned(
+                                    field,
+                                    "#[gpu] Vec<T> fields store through this struct's own \
+                                     #[derive(pulsar_scenedb::SceneStore)] (add the \
+                                     `scene_store` flag to #[engine_class]). This derive \
+                                     generates packed-scalar companions only.",
+                                )
+                                .to_compile_error()
+                                .into();
+                            }
+                        } else {
+                            let field_ident = field.ident.clone().unwrap();
+                            let override_ = match parse_gpu_attr(field) {
+                                Ok(o) => o,
+                                Err(err) => return err.to_compile_error().into(),
+                            };
+                            gpu_fields.push(GpuLeafField { ident: field_ident, field_ty: field.ty.clone(), override_ });
+                        }
                     }
 
                     if has_sub_props {
@@ -452,6 +491,14 @@ fn is_vec_type(ty: &syn::Type) -> bool {
     type_path.path.segments.last().map(|s| s.ident == "Vec").unwrap_or(false)
 }
 
+/// Syntactic-only check that `ty` is `pulsar_world_registry::GpuHeavy<T>` --
+/// same last-segment style as `is_vec_type`. Used solely by the GPU ownership
+/// boundary errors; heavy storage itself is SceneDB's SceneStore concern.
+fn is_gpu_heavy_shape(ty: &syn::Type) -> bool {
+    let syn::Type::Path(type_path) = ty else { return false };
+    type_path.path.segments.last().map(|s| s.ident == "GpuHeavy").unwrap_or(false)
+}
+
 #[proc_macro_attribute]
 pub fn engine_class(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated::<Meta, syn::Token![,]>::parse_terminated);
@@ -607,6 +654,17 @@ pub fn engine_class(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         quote! {}
     };
+    // Same marker-attribute mechanism, for the GPU ownership boundary: a
+    // `scene_store` struct's `#[gpu] Vec<T>`/`GpuHeavy<T>` fields are
+    // SceneDB's own `#[derive(SceneStore)]` storage (var-len / handle-split
+    // paths), NOT this derive's packed companions. The marker is how
+    // `derive_engine_class` -- which can never see the derive list --
+    // distinguishes "routed to SceneDB, skip" from "misuse, reject".
+    let scene_store_marker_attr = if add_scene_store || has_scene_store_derive {
+        quote! { #[engine_class_scene_store] }
+    } else {
+        quote! {}
+    };
 
     let sub_props_marker_impl = if no_register {
         let name = &item_struct.ident;
@@ -690,6 +748,7 @@ pub fn engine_class(attr: TokenStream, item: TokenStream) -> TokenStream {
         #no_register_attr
         #serialize_marker_attr
         #deserialize_marker_attr
+        #scene_store_marker_attr
         #item_struct
         #sub_props_marker_impl
         #runtime_registration

--- a/crates/core/engine_class_derive/tests/gpu_boundary.rs
+++ b/crates/core/engine_class_derive/tests/gpu_boundary.rs
@@ -1,0 +1,52 @@
+//! GPU ownership boundary — positive cases.
+//!
+//! The negative side (unrouted `#[gpu] Vec<T>` / `#[gpu] GpuHeavy<T>`
+//! fields are compile errors) is enforced by the derive itself; those
+//! messages were verified verbatim during review. This file pins the
+//! positive contract: a `scene_store`-routed struct's var-len/heavy fields
+//! expand cleanly (SceneDB owns them), and packed-only structs are
+//! unaffected by the boundary logic.
+
+use engine_class_derive::engine_class;
+
+/// Mirrors `StaticMeshComponent`'s shape: `scene_store` routing with
+/// `#[gpu] Vec<T>` fields whose storage is SceneDB's own
+/// `#[derive(SceneStore)]` concern. Must expand without error; the derive
+/// contributes no packed companion fields for them.
+#[engine_class(category = "Test", default, clone, debug, no_register, scene_store)]
+pub struct BoundarySceneStoreRouted {
+    #[property]
+    pub label: f32,
+    #[gpu(mirror = Once)]
+    pub vertices: Vec<[f32; 3]>,
+}
+
+/// Packed-only struct: every `#[gpu]` field is a scalar, so the packed
+/// companion path applies exactly as before the boundary existed.
+#[engine_class(category = "Test", default, clone, debug, no_register)]
+pub struct BoundaryPackedOnly {
+    #[property]
+    #[gpu]
+    pub intensity: f32,
+}
+
+#[test]
+fn scene_store_routed_struct_expands_and_reflects() {
+    let value = BoundarySceneStoreRouted {
+        label: 7.0,
+        vertices: vec![[1.0, 2.0, 3.0]],
+    };
+    // Reflection metadata is unaffected by the boundary: scalar properties
+    // still register normally.
+    assert_eq!(value.label, 7.0);
+}
+
+#[test]
+fn packed_only_struct_still_mirrors_scalars() {
+    use pulsar_world_registry::GpuMirrored;
+    let value = BoundaryPackedOnly { intensity: 0.5 };
+    let mirror = GpuMirrored::to_gpu_mirror(&value);
+    // One packed leaf; its bytes ride `GpuRepr<f32>` exactly as before the
+    // boundary existed.
+    assert_eq!(mirror.intensity.0, 0.5);
+}


### PR DESCRIPTION
Follow-up to #676. \#[engine_class(..., scene_store)]\ now stamps an \ngine_class_scene_store\ marker attribute (same consumed-marker pattern as \ngine_class_serialize\), letting the EngineClass derive — which can never see the derive list — distinguish SceneDB-routed structs from misuse:

- **routed** (marker present): \#[gpu] Vec<T>\/\GpuHeavy<T>\ fields skip packed classification silently — their storage is SceneDB's own SceneStore derive (StaticMeshComponent's vertices/indices: unchanged, workspace compiles).
- **unrouted**: hard compile errors pointing at the \scene_store\ flag. Verified verbatim:
  - \\#[gpu] Vec<T> fields store through this struct's own #[derive(pulsar_scenedb::SceneStore)] (add the scene_store flag to #[engine_class]). This derive generates packed-scalar companions only.\\
  - \\#[gpu] GpuHeavy<T> fields use SceneDB's heavy/handle-split storage, owned by this struct's own #[derive(pulsar_scenedb::SceneStore)] …\\

\struct_has_gpu_vec_field\ deliberately stays: routed structs with gpu Vec fields must keep skipping auto-Copy. New \gpu_boundary.rs\ pins the positive contract; packed suite 9/9, world_registry 33/33, full workspace check green.