### PR TITLE
Phase B6: unify SceneFile/LevelFile onto one canonical scene schema (#557)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,7 @@ dependencies = [
  "pulsar_pie_abi",
  "pulsar_reflection",
  "pulsar_scene",
+ "pulsar_scene_format",
  "pulsar_scenedb",
  "pulsar_script_object_model",
  "pulsar_world_registry",
@@ -8942,13 +8943,23 @@ dependencies = [
 name = "pulsar_scene"
 version = "0.1.0"
 dependencies = [
- "engine_fs",
  "glam 0.33.5",
  "helio",
  "helio-asset-compat",
  "helio_component",
  "pulsar_events",
  "pulsar_reflection",
+ "pulsar_scene_format",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "pulsar_scene_format"
+version = "0.1.0"
+dependencies = [
+ "engine_fs",
  "serde",
  "serde_json",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ engine_class_derive                = { path = "crates/core/engine_class_derive" 
 pulsar_world_registry              = { path = "crates/core/pulsar_world_registry" }
 pulsar_script_object_model         = { path = "crates/core/pulsar_script_object_model" }
 pulsar_scene                       = { path = "crates/subsystems/pulsar_scene" }
+# Canonical scene/level JSON schema (Pulsar-Native#557). Deliberately
+# dependency-light so both the editor and the game runtime can depend on it
+# without depending on each other.
+pulsar_scene_format                = { path = "crates/subsystems/pulsar_scene_format" }
 pulsar_terrain                     = { path = "crates/subsystems/pulsar_terrain" }
 
 # ---------- Agent Providers ----------
@@ -194,7 +198,13 @@ notify = "8.2.0"
 lsp-types = "0.97.0"
 directories = "6.0.0"
 itertools = "0.15.0"
-rapier3d = { version = "0.35.0", features = ["simd-stable"] }
+# Pinned back to 0.34.0: rapier3d 0.35 removed the `simd-stable` feature, so
+# the automated 0.34 -> 0.35 bump (c760bd500) left the workspace unresolvable
+# ("package `engine_backend` depends on `rapier3d` with feature `simd-stable`
+# but `rapier3d` does not have that feature") while Cargo.lock still pinned
+# 0.34.0. Re-bump deliberately, together with picking the 0.35 replacement for
+# `simd-stable` (`simd8` or plain defaults) and refreshing the lock.
+rapier3d = { version = "0.34.0", features = ["simd-stable"] }
 sysuri = "0.4.0"
 urlencoding = "2.1.3"
 ropey = { version = "=2.0.0-beta.1", features = ["metric_utf16", "metric_lines_lf"] }
@@ -335,6 +345,14 @@ tool_registry_macros = { path = "crates/third-party/toolbelt/crates/tool_registr
 psgc = { path = "crates/third-party/psgc/crates/psgc" }
 wgsl_std = { path = "crates/third-party/psgc/crates/wgsl_std" }
 
+# Kept, NOT removable yet (re-verified in Pulsar-Native#557): `pulsar_scenedb`
+# (SceneDB, itself a `[patch]`ed git dep below) depends on `pulsar_reflection`
+# at rev b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff, not at the workspace pin
+# 745ee787cc63288463c170aafb778672db8e85ac. Deleting this block therefore
+# resolves TWO `pulsar_reflection` packages into the graph -- which splits the
+# reflection registry types exchanged across the SceneDB/Helio seam -- rather
+# than the one the block guarantees. Drop it only once SceneDB repins to the
+# same rev the workspace does.
 [patch."https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection"]
 pulsar_reflection = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "745ee787cc63288463c170aafb778672db8e85ac" }
 pulsar_reflection_derive = { git = "https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection", rev = "745ee787cc63288463c170aafb778672db8e85ac" }

--- a/crates/core/engine_backend/Cargo.toml
+++ b/crates/core/engine_backend/Cargo.toml
@@ -46,6 +46,9 @@ pulsar_script_object_model.workspace = true
 
 # Shared scene loading — canonical implementation used by both engine and game
 pulsar_scene.workspace = true
+# Canonical scene/level JSON schema (Pulsar-Native#557): `scene::ObjectType`/
+# `LightType`/`MeshType`/`ComponentInstance` are re-exports of it.
+pulsar_scene_format.workspace = true
 helio_component.workspace = true
 engine_fs.workspace = true
 

--- a/crates/core/engine_backend/src/scene/metadata.rs
+++ b/crates/core/engine_backend/src/scene/metadata.rs
@@ -8,37 +8,20 @@
 //! zero callers outside `SceneMetadataDb`'s own now-removed object/
 //! hierarchy surface. See `scene::mod`'s module doc.
 
-use serde::{Deserialize, Serialize};
-
 /// Editor-side unique identifier for scene objects.
 ///
 /// This is separate from Helio's internal IDs to allow for folders and other
 /// organizational constructs that don't exist in Helio.
-pub type EditorObjectId = String;
+///
+/// Re-exported from [`pulsar_scene_format`] since Pulsar-Native#557: the id
+/// is part of the level file's wire format, so it is declared alongside it.
+pub use pulsar_scene_format::ObjectId as EditorObjectId;
 
-/// Component instance attached to a scene object
+/// Component instance attached to a scene object.
 ///
 /// Uses the reflection system for property inspection and editing.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ComponentInstance {
-    /// Class name from the component registry (e.g., "PhysicsComponent")
-    pub class_name: String,
-
-    /// Whether the component is active.
-    ///
-    /// Disabled components remain serialized but are ignored by scene-property
-    /// projection and behave as if they were absent.
-    #[serde(default = "default_component_enabled")]
-    pub enabled: bool,
-
-    /// Serialized component data
-    ///
-    /// NOTE: In the full implementation, this would be Box<dyn EngineClass>,
-    /// but that's not directly serializable. For now, we store serialized JSON
-    /// and reconstruct via the registry on load.
-    pub data: serde_json::Value,
-}
-
-fn default_component_enabled() -> bool {
-    true
-}
+///
+/// Re-exported from [`pulsar_scene_format`] since Pulsar-Native#557 -- this
+/// type IS the level file's `components` section entry, so it belongs to the
+/// canonical schema rather than being declared a second time here.
+pub use pulsar_scene_format::ComponentInstance;

--- a/crates/core/engine_backend/src/scene/mod.rs
+++ b/crates/core/engine_backend/src/scene/mod.rs
@@ -68,7 +68,6 @@ pub use world_store::{
 
 use bitflags::bitflags;
 use glam::Mat4;
-use serde::{Deserialize, Serialize};
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -79,34 +78,17 @@ use serde::{Deserialize, Serialize};
 /// (`SceneDatabase` and its ~50 call sites) already spells it as.
 pub type ObjectId = EditorObjectId;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ObjectType {
-    Empty,
-    Folder,
-    Camera,
-    Light(LightType),
-    Mesh(MeshType),
-    ParticleSystem,
-    AudioSource,
-    Blueprint,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LightType {
-    Directional,
-    Point,
-    Spot,
-    Area,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MeshType {
-    Cube,
-    Sphere,
-    Cylinder,
-    Plane,
-    Custom,
-}
+/// Object classification and its two payload enums.
+///
+/// Re-exported from [`pulsar_scene_format`] since Pulsar-Native#557 (Phase
+/// B6): these three enums are part of the level file's wire format, and
+/// having the editor's copy here and the runtime's copy in `pulsar_scene`
+/// is exactly the drift that issue exists to kill -- the runtime's copy had
+/// silently fallen behind by three `ObjectType` variants and `LightType::
+/// Area`. The canonical definitions carry the editor's full coverage plus a
+/// lenient deserializer (unrecognised spellings degrade to `Empty`/`Cube`/
+/// `Point` instead of failing the parse).
+pub use pulsar_scene_format::{LightType, MeshType, ObjectType};
 
 bitflags! {
     // `Debug`/`PartialEq`/`Eq` weren't previously derived -- added so

--- a/crates/core/engine_backend/src/scene/runtime_level.rs
+++ b/crates/core/engine_backend/src/scene/runtime_level.rs
@@ -27,19 +27,16 @@
 //! `components` entry for an object wins over that object's own
 //! `component_instances`.
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
 use pulsar_scene::component_instances_from_props;
-use pulsar_scene::format::{BlueprintBindings, ObjectType as FileObjectType, SceneFile};
-use serde_json::Value;
-
-use crate::scene::{
-    LightType, MeshType, ObjectSnapshot, ObjectType, RenderProps, Transform, Visibility,
-    WorldSceneStore,
+use pulsar_scene::format::{
+    BlueprintBindings, ComponentInstance, LevelEditorFileState, SceneFile,
 };
+
+use crate::scene::{ObjectSnapshot, RenderProps, Transform, Visibility, WorldSceneStore};
 
 /// Errors from [`RuntimeLevel::load`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -159,10 +156,10 @@ impl RuntimeLevel {
         file: SceneFile,
         store: &mut WorldSceneStore,
     ) -> Result<(), RuntimeLevelError> {
-        let version = version_string(&file.version);
-        // Same accepted set as the editor's own loader: 1.x and 2.x.
-        if !version.starts_with("1.") && !version.starts_with("2.") && version != "1" {
-            return Err(RuntimeLevelError::UnsupportedVersion(version));
+        // Same accepted set as the editor's own loader: 1.x and 2.x -- now
+        // literally the same check, on the canonical type (#557).
+        if !file.is_supported_version() {
+            return Err(RuntimeLevelError::UnsupportedVersion(file.version_string()));
         }
 
         // Parent-before-child order is the format's own DFS guarantee (see
@@ -174,18 +171,16 @@ impl RuntimeLevel {
             message: error.to_string(),
         })?;
 
-        let persisted = persisted_components(&file.components);
         for obj in &file.objects {
             let Some(entity) = store.entity_for(&obj.id) else { continue };
-            let instances = match persisted.get(&obj.id) {
+            let instances = match file.components.get(&obj.id) {
                 Some(records) if !records.is_empty() => records.clone(),
                 _ => component_instances_from_props(
                     &obj.props,
                     obj.component_instances.as_ref(),
                 )
                 .into_iter()
-                .map(|(index, class_name, data)| ComponentRecord {
-                    index,
+                .map(|(_index, class_name, data)| ComponentInstance {
                     class_name,
                     data,
                     enabled: true,
@@ -217,28 +212,12 @@ impl RuntimeLevel {
     }
 }
 
-/// One component instance record -- either parsed from the file's persisted
-/// components array (which carries its own enabled flag) or converted from
-/// `component_instances_from_props`'s `(index, class_name, data)` tuples
-/// (where presence means enabled).
-#[derive(Clone, Debug)]
-struct ComponentRecord {
-    #[allow(dead_code)]
-    index: usize,
-    class_name: String,
-    data: Value,
-    enabled: bool,
-}
-
-fn version_string(version: &Value) -> String {
-    match version {
-        Value::String(s) => s.clone(),
-        Value::Number(n) => n.to_string(),
-        other => other.to_string(),
-    }
-}
-
 /// Map a file-format object onto the store's snapshot bridge type.
+///
+/// Since #557 there is no enum translation step here: `ObjectType`/
+/// `LightType`/`MeshType` on both sides are the same canonical types, and
+/// the v1 flat transform is already folded into `transform` by the schema's
+/// deserializer (`world_position()` and friends just read it back).
 fn object_snapshot(obj: &pulsar_scene::format::SceneObject) -> ObjectSnapshot {
     ObjectSnapshot {
         stable_id: obj.id.clone(),
@@ -250,61 +229,12 @@ fn object_snapshot(obj: &pulsar_scene::format::SceneObject) -> ObjectSnapshot {
             scale: obj.world_scale(),
         },
         visibility: Visibility { visible: obj.visible, locked: obj.locked },
-        object_type: object_type(obj.object_type),
+        object_type: obj.object_type,
         render_props: RenderProps {
             props: obj.props.clone(),
             component_instances: obj.component_instances.clone(),
         },
     }
-}
-
-/// `pulsar_scene`'s loader-facing object classification ->
-/// `engine_backend`'s store-facing one.
-fn object_type(object_type: FileObjectType) -> ObjectType {
-    match object_type {
-        FileObjectType::Empty | FileObjectType::Unknown => ObjectType::Empty,
-        FileObjectType::Folder => ObjectType::Folder,
-        FileObjectType::Camera => ObjectType::Camera,
-        FileObjectType::Mesh(mesh) => ObjectType::Mesh(match mesh {
-            pulsar_scene::format::MeshType::Cube => MeshType::Cube,
-            pulsar_scene::format::MeshType::Sphere => MeshType::Sphere,
-            pulsar_scene::format::MeshType::Cylinder => MeshType::Cylinder,
-            pulsar_scene::format::MeshType::Plane => MeshType::Plane,
-            pulsar_scene::format::MeshType::Custom => MeshType::Custom,
-        }),
-        FileObjectType::Light(light) => ObjectType::Light(match light {
-            pulsar_scene::format::LightType::Directional => LightType::Directional,
-            pulsar_scene::format::LightType::Point => LightType::Point,
-            pulsar_scene::format::LightType::Spot => LightType::Spot,
-        }),
-    }
-}
-
-/// Parse the editor's persisted components section:
-/// `{ "<object_id>": [ { "class_name": ..., "data": ..., "enabled": ... } ] }`.
-/// Lenient by design -- entries missing a class name are skipped; a missing
-/// `enabled` flag means enabled (matching how the editor treats inline
-/// instances).
-fn persisted_components(components: &Value) -> HashMap<String, Vec<ComponentRecord>> {
-    let mut out = HashMap::new();
-    let Some(map) = components.as_object() else { return out };
-    for (object_id, entries) in map {
-        let Some(array) = entries.as_array() else { continue };
-        let records = array
-            .iter()
-            .enumerate()
-            .filter_map(|(index, entry)| {
-                Some(ComponentRecord {
-                    index,
-                    class_name: entry.get("class_name")?.as_str()?.to_string(),
-                    data: entry.get("data").cloned().unwrap_or(Value::Null),
-                    enabled: entry.get("enabled").and_then(Value::as_bool).unwrap_or(true),
-                })
-            })
-            .collect();
-        out.insert(object_id.clone(), records);
-    }
-    out
 }
 
 /// Hydrate/remove every registered class's typed World value for `entity`
@@ -316,7 +246,7 @@ fn hydrate_components(
     store: &mut WorldSceneStore,
     entity: pulsar_scenedb::Entity,
     object_id: &str,
-    instances: &[ComponentRecord],
+    instances: &[ComponentInstance],
 ) {
     for class_name in pulsar_world_registry::registered_world_component_classes() {
         match instances.iter().find(|r| r.enabled && r.class_name == *class_name) {
@@ -344,17 +274,9 @@ fn hydrate_components(
 }
 
 /// Read `editor.camera` out of a level file's editor section, if present.
-fn editor_camera(editor: &Value) -> Option<EditorCamera> {
-    let cam = editor.get("camera")?;
-    let pos = cam.get("position")?.as_array()?;
-    if pos.len() < 3 {
-        return None;
-    }
-    Some(EditorCamera {
-        position: [pos[0].as_f64()? as f32, pos[1].as_f64()? as f32, pos[2].as_f64()? as f32],
-        yaw: cam.get("yaw").and_then(Value::as_f64).unwrap_or(0.0) as f32,
-        pitch: cam.get("pitch").and_then(Value::as_f64).unwrap_or(0.0) as f32,
-    })
+fn editor_camera(editor: &Option<LevelEditorFileState>) -> Option<EditorCamera> {
+    let cam = editor.as_ref()?.camera?;
+    Some(EditorCamera { position: cam.position, yaw: cam.yaw, pitch: cam.pitch })
 }
 
 #[cfg(test)]
@@ -362,6 +284,7 @@ mod tests {
     use super::*;
     use crate::scene::StableId;
     use helio_component::components::LightComponent;
+    use serde_json::Value;
 
     const SAMPLE_LEVEL: &str = r#"{
         "version": "2.1",
@@ -431,7 +354,16 @@ mod tests {
         if let Some(instances) = instances {
             file.objects[0].component_instances = Some(instances);
         }
-        file.components = components_section;
+        // Routed through the canonical schema's own lenient `components`
+        // deserializer (#557) rather than assigned as a raw `Value`, so the
+        // fixture still exercises the real parse path now that the field is
+        // typed.
+        file.components = serde_json::from_value::<SceneFile>(serde_json::json!({
+            "version": "2.1",
+            "components": components_section,
+        }))
+        .expect("components section parses")
+        .components;
         file
     }
 

--- a/crates/core/pulsar_docs/Cargo.toml
+++ b/crates/core/pulsar_docs/Cargo.toml
@@ -23,7 +23,12 @@ tracing = { workspace = true }
 [build-dependencies]
 syn = { workspace = true, features = ["full", "parsing", "extra-traits", "visit"] }
 quote = { workspace = true }
-prettyplease = "0.3"
+# Must track the `syn` major this crate parses with (workspace `syn` is 2.x):
+# prettyplease 0.3 takes `syn` 3.0 types, so requesting it here resolved BOTH
+# syn majors into the build graph and `prettyplease::unparse(&file)` stopped
+# type-checking ("expected `syn::file::File`, found `syn::File`"). Cargo.lock
+# had never picked 0.3 up, so the mismatch only surfaced on a re-resolve.
+prettyplease = "0.2"
 walkdir = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -32,10 +32,9 @@ use engine_fs::virtual_fs;
 use parking_lot::RwLock;
 use pulsar_reflection::{apply_scene_props_for_class, registered_scene_props_classes};
 use pulsar_scenedb::Entity;
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::any::Any;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -43,31 +42,29 @@ use std::sync::Arc;
 
 pub use engine_backend::scene::{LightType, MeshType, ObjectId, ObjectType, WorldSceneStore};
 
-// ── Transform ─────────────────────────────────────────────────────────────
+// ── Level file schema (Pulsar-Native#557) ─────────────────────────────────
+//
+// The editor no longer declares its own serde types for the level file. Every
+// name below is an alias of `pulsar_scene_format`, the single canonical
+// schema the game runtime's `pulsar_scene::{SceneFile, SceneObject}` also
+// aliases. One serde implementation, so the two sides cannot drift; the
+// aliases keep the ~250 editor call sites spelling things the way they
+// always have.
+//
+// What the editor gained from the merge:
+// - v1 flat-transform files (`position`/`rotation`/`scale` at the top level of
+//   an object, no nested `transform`) now open here too. They previously only
+//   worked in the runtime loader.
+// - unrecognised `object_type`/`MeshType`/`LightType` spellings degrade to
+//   `Empty`/`Cube`/`Point` instead of failing the whole load.
+// - `metadata` is optional: a runtime- or hand-authored file without it opens.
 
 /// Editor transform: position, Euler rotation (degrees), and scale.
 ///
 /// Stored inline in `SceneObjectData` for easy UI access. The underlying
 /// `WorldSceneStore` stores the same values behind one `RwLock` shared with
 /// the renderer.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Transform {
-    pub position: [f32; 3],
-    pub rotation: [f32; 3],
-    pub scale: [f32; 3],
-}
-
-impl Default for Transform {
-    fn default() -> Self {
-        Self {
-            position: [0.0, 0.0, 0.0],
-            rotation: [0.0, 0.0, 0.0],
-            scale: [1.0, 1.0, 1.0],
-        }
-    }
-}
-
-// ── SceneObjectData ────────────────────────────────────────────────────────
+pub type Transform = pulsar_scene::SceneTransform;
 
 /// Snapshot of a single scene object – the primary data type used by editor panels.
 ///
@@ -76,30 +73,10 @@ impl Default for Transform {
 /// `update_object`. Transform data is stored both here (for easy editing) and
 /// in the underlying `WorldSceneStore` (shared with the renderer); calling
 /// `update_object` keeps them in sync.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SceneObjectData {
-    pub id: ObjectId,
-    pub name: String,
-    pub object_type: ObjectType,
-    pub transform: Transform,
-    pub visible: bool,
-    pub locked: bool,
-    /// Parent object ID (`None` = root level).
-    pub parent: Option<ObjectId>,
-    /// Direct children (populated by `SceneDatabase` on read, ignored on write).
-    pub children: Vec<ObjectId>,
-    pub scene_path: String,
-    /// Type-specific properties that round-trip through the level file.
-    /// Lights: `"color_r"`, `"color_g"`, `"color_b"`, `"intensity"`, `"range"`.
-    ///
-    /// ⚠ This field does **not** contain `__component_instances`. Component
-    /// data flows exclusively through `SceneDatabase::add_component` / etc.
-    #[serde(default)]
-    pub props: std::collections::HashMap<String, serde_json::Value>,
-    /// Reflection-based component instances (synced from metadata_db).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub component_instances: Option<serde_json::Value>,
-}
+///
+/// Field-for-field the same type as `pulsar_scene::SceneObject` — see the
+/// module note above.
+pub type SceneObjectData = pulsar_scene::SceneObject;
 
 // ── Property change tracking ─────────────────────────────────────────────
 
@@ -1568,7 +1545,10 @@ impl SceneDatabase {
             .map(|file| file.blueprint_bindings)
             .unwrap_or_default();
         let level_file = LevelFile {
-            version: "2.1".into(),
+            // The canonical schema carries `version` as a `serde_json::Value`
+            // so it can round-trip both the editor's `"2.1"` string and v1's
+            // bare `1`; the emitted bytes are unchanged.
+            version: Value::String("2.1".into()),
             objects,
             components,
             blueprint_bindings: preserved_bindings,
@@ -1606,12 +1586,17 @@ impl SceneDatabase {
         let json = String::from_utf8(bytes).map_err(|e| format!("File is not valid UTF-8: {e}"))?;
         let level_file: LevelFile =
             serde_json::from_str(&json).map_err(|e| format!("Failed to parse JSON: {e}"))?;
-        if !level_file.version.starts_with("2.") && !level_file.version.starts_with("1.") {
+        // Same gate as the runtime's `RuntimeLevel::load` -- literally the
+        // same call now that both sides share the canonical type (#557).
+        if !level_file.is_supported_version() {
             return Err(format!(
                 "Unsupported scene version: {}. Expected 1.x or 2.x",
-                level_file.version
+                level_file.version_string()
             ));
         }
+        // Captured before the section below consumes `level_file` field by
+        // field (`version_string` borrows the whole value).
+        let version = level_file.version_string();
         self.clear();
         // Objects are stored in DFS order so parents are always inserted first.
         let has_persisted_components = !level_file.components.is_empty();
@@ -1636,7 +1621,7 @@ impl SceneDatabase {
         tracing::info!(
             "Scene loaded from: {} (version: {})",
             path.as_ref().display(),
-            level_file.version
+            version
         );
         Ok(level_file.editor.and_then(|editor| editor.camera))
     }
@@ -1937,48 +1922,23 @@ impl Default for SceneDatabase {
 }
 
 // ── Level File Format ──────────────────────────────────────────────────────
+//
+// Aliases of the canonical schema (Pulsar-Native#557) — see the note beside
+// `SceneObjectData` above. The `blueprint_bindings` section (#650) still has
+// no authoring UI here; `save_to_file` preserves whatever the file on disk
+// carried, mirroring how `preserved_editor` keeps camera state.
 
-/// JSON level file (version 2.x).
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LevelFile {
-    pub version: String,
-    pub objects: Vec<SceneObjectData>,
-    /// Reflection component instances keyed by object id.
-    #[serde(default)]
-    pub components: HashMap<ObjectId, Vec<ComponentInstance>>,
-    /// Per-object Blueprint class bindings keyed by StableId (#650).
-    ///
-    /// The editor has no binding-authoring UI yet (editor phase F); the
-    /// field exists so hand-authored or future sections survive editor
-    /// re-saves instead of being silently dropped. `save_to_file` preserves
-    /// it by reading it back from the file on disk, mirroring how
-    /// `preserved_editor` keeps camera state.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub blueprint_bindings: pulsar_scene::BlueprintBindings,
-    pub metadata: LevelMetadata,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub editor: Option<LevelEditorFileState>,
-}
+/// JSON level file (version 1.x / 2.x).
+pub type LevelFile = pulsar_scene::SceneFile;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LevelMetadata {
-    pub created: String,
-    pub modified: String,
-    pub editor_version: String,
-}
+/// Authoring metadata written into the level file.
+pub type LevelMetadata = pulsar_scene::LevelMetadata;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LevelEditorFileState {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub camera: Option<LevelEditorCameraState>,
-}
+/// The level file's `editor` section.
+pub type LevelEditorFileState = pulsar_scene::LevelEditorFileState;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LevelEditorCameraState {
-    pub position: [f32; 3],
-    pub yaw: f32,
-    pub pitch: f32,
-}
+/// Persisted editor camera (position + yaw/pitch in radians).
+pub type LevelEditorCameraState = pulsar_scene::LevelEditorCameraState;
 
 // ── Blueprint helpers ──────────────────────────────────────────────────────
 

--- a/crates/subsystems/pulsar_scene/Cargo.toml
+++ b/crates/subsystems/pulsar_scene/Cargo.toml
@@ -15,7 +15,9 @@ tracing    = { workspace = true }
 pulsar_reflection  = { workspace = true }
 helio_component    = { workspace = true }
 pulsar_events      = { workspace = true }
-engine_fs          = { workspace = true }
+# Canonical scene/level JSON schema (Pulsar-Native#557) — `format` is a
+# re-export of it plus the runtime-only projected-prop extension trait.
+pulsar_scene_format = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/subsystems/pulsar_scene/src/format.rs
+++ b/crates/subsystems/pulsar_scene/src/format.rs
@@ -1,458 +1,69 @@
-//! Scene file format — the canonical on-disk representation of a Pulsar scene.
+//! Scene file format — the game runtime's view of the canonical schema.
 //!
-//! Supports both the v1 flat format and the v2.x nested-transform editor format.
+//! Since Pulsar-Native#557 (Phase B6) this module owns **no** serde
+//! definitions. The one canonical Rust type set with the one serde
+//! implementation lives in [`pulsar_scene_format`]; everything here is a
+//! re-export of it, so the runtime and the editor can no longer drift apart
+//! on the wire format. See that crate's module doc for the format itself
+//! (v1 flat vs. v2.x nested, and the leniency contract).
 //!
-//! # v2.x format (editor output)
-//! - `version` is a string (e.g. `"2.1"`)
-//! - `transform` is a nested object: `{ "position": [...], "rotation": [...], "scale": [...] }`
-//! - Unknown `object_type` values (e.g. `"ParticleSystem"`) are silently treated as `Empty`
-//! - Light `color`, `intensity`, `range` live directly in `props`
-//! - A `__component_instances` array in `props` may duplicate some data (ignored by loader)
-//!
-//! # v1 format (runtime-only, flat)
-//! - `version` is an integer (`1`)
-//! - `position`, `rotation`, `scale` are top-level fields on each object
+//! What *is* defined here is [`SceneObjectRuntimeExt`]: the projected-prop
+//! accessors (`mat_base_color`, `light_color`, `mesh_asset`, …) that read a
+//! scene object's props through the reflection system. Those are runtime
+//! ergonomics, not schema — they need `pulsar_reflection`, which the
+//! dependency-light schema crate deliberately does not depend on — so they
+//! ride on an extension trait implemented for the canonical
+//! [`SceneObject`]. The editor never sees them; the game loader keeps them
+//! by importing this trait.
 
-use engine_fs::virtual_fs;
 use pulsar_reflection::apply_scene_props_for_class;
-use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
-// ── Top-level file ─────────────────────────────────────────────────────────────
+// ── The canonical schema, re-exported verbatim ────────────────────────────────
 
-/// An entire scene read from a scene file.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SceneFile {
-    /// Format version — accepts both strings (`"2.1"`) and integers (`1`).
-    #[serde(default = "default_version_value")]
-    pub version: Value,
+pub use pulsar_scene_format::{
+    BlueprintBinding, BlueprintBindings, ComponentInstance, LevelEditorCameraState,
+    LevelEditorFileState, LevelMetadata, LightType, MeshType, ObjectId, ObjectType, SceneFile,
+    SceneLoadError, SceneObject, SceneTransform,
+};
 
-    /// All objects in depth-first order (parents before children).
-    #[serde(default)]
-    pub objects: Vec<SceneObject>,
+// ── Runtime-only projected-prop accessors ─────────────────────────────────────
 
-    // Editor-only top-level sections — loaded but unused at runtime.
-    #[serde(default, skip_serializing)]
-    pub components: Value,
-    #[serde(default, skip_serializing)]
-    pub metadata: Value,
-    #[serde(default, skip_serializing)]
-    pub editor: Value,
-
-    // ── Blueprint class bindings (#650) ───────────────────────────────────
-    /// Per-object Blueprint class bindings keyed by the object's **StableId**
-    /// (`SceneObject::id`), never its display name — so renaming an object
-    /// never orphans a binding. Multiple classes may bind to one object.
-    ///
-    /// Additive extension: older level files lack the key entirely and
-    /// deserialize to an empty map; files without bindings serialize without
-    /// it, staying byte-compatible with the pre-#650 format.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub blueprint_bindings: BlueprintBindings,
-}
-
-fn default_version_value() -> Value {
-    Value::Number(1.into())
-}
-
-impl SceneFile {
-    /// Load a scene from a JSON file.
-    pub fn load(path: &std::path::Path) -> Result<Self, SceneLoadError> {
-        tracing::debug!(path = %path.display(), "Reading scene file from disk");
-        let bytes = virtual_fs::read_file(path).map_err(|e| SceneLoadError::Io(e.to_string()))?;
-        let text = String::from_utf8(bytes).map_err(|e| SceneLoadError::Io(e.to_string()))?;
-        tracing::debug!(bytes = text.len(), "Scene file read OK, parsing JSON");
-        let scene: Self =
-            serde_json::from_str(&text).map_err(|e| SceneLoadError::Parse(e.to_string()))?;
-        tracing::info!(
-            path = %path.display(),
-            version = %scene.version,
-            objects = scene.objects.len(),
-            "Scene file parsed"
-        );
-        Ok(scene)
-    }
-
-    /// Save a scene to a JSON file (pretty-printed).
-    pub fn save(&self, path: &std::path::Path) -> Result<(), SceneLoadError> {
-        if let Some(parent) = path.parent() {
-            virtual_fs::create_dir_all(parent).map_err(|e| SceneLoadError::Io(e.to_string()))?;
-        }
-        let text =
-            serde_json::to_string_pretty(self).map_err(|e| SceneLoadError::Parse(e.to_string()))?;
-        virtual_fs::write_file(path, text.as_bytes()).map_err(|e| SceneLoadError::Io(e.to_string()))
-    }
-}
-
-// ── Blueprint class bindings (#650) ───────────────────────────────────────────
-
-/// One compiled-Blueprint class bound to one scene object (#650).
+/// Reflection-projected reads over a [`SceneObject`]'s props — the game
+/// runtime's convenience layer, deliberately kept off the schema type.
 ///
-/// At play-mode load each binding becomes exactly one dispatcher instance
-/// whose component ops address the bound object's entity. The class must
-/// exist as compiled bytecode at
-/// `<project>/src/classes/<class_name>/events/.build/bytecode.json` — the
-/// same layout the generated `engine_main` auto-discovers.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BlueprintBinding {
-    /// Compiled Blueprint class name — matches the bytecode's
-    /// `source_class` and the class directory under `<project>/src/classes/`.
-    pub class_name: String,
+/// Each accessor works against [`Self::projected_props`], i.e. the object's
+/// own `props` with every component instance's data projected in through its
+/// registered `ScenePropsProjector`. That means renaming a field on, say,
+/// `LightComponent` only requires updating that component's projector, never
+/// this module.
+pub trait SceneObjectRuntimeExt {
+    /// A copy of `props` with all component-instance data projected into it
+    /// via registered `ScenePropsProjector` implementations.
+    fn projected_props(&self) -> HashMap<String, Value>;
 
-    /// Per-instance variable overrides: variable name → JSON value in the
-    /// variable's natural JSON form (`7.5`, `"hello"`, `[1.0, 2.0]`, …).
-    /// Applied to this instance's state arena at spawn; variables not listed
-    /// keep their graph-authored defaults. Unknown names are ignored by the
-    /// dispatcher (the variable layout is the authority).
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub overrides: HashMap<String, Value>,
+    /// The `mesh_asset` path from this object's props or its component
+    /// instances, projected through the reflection system.
+    fn mesh_asset(&self) -> Option<String>;
+
+    fn mat_base_color(&self) -> [f32; 4];
+    fn mat_roughness(&self) -> f32;
+    fn mat_metallic(&self) -> f32;
+    fn mat_emissive(&self) -> [f32; 3];
+    fn mat_emissive_strength(&self) -> f32;
+
+    fn light_color(&self) -> [f32; 3];
+    fn light_intensity(&self) -> f32;
+    fn light_range(&self) -> f32;
+    fn light_inner_angle(&self) -> f32;
+    fn light_outer_angle(&self) -> f32;
 }
 
-/// A whole file's bindings: object StableId → that object's class bindings.
-///
-/// A `BTreeMap` so load-time spawning order is deterministic regardless of
-/// the JSON key order on disk.
-pub type BlueprintBindings = BTreeMap<String, Vec<BlueprintBinding>>;
-
-// ── Transform (nested, v2.x format) ───────────────────────────────────────────
-
-/// World-space transform stored as a nested object (editor v2.x format).
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct SceneTransform {
-    #[serde(default)]
-    pub position: [f32; 3],
-
-    /// Euler rotation in degrees, YXZ order (pitch, yaw, roll as stored by editor).
-    #[serde(default)]
-    pub rotation: [f32; 3],
-
-    #[serde(default = "default_scale")]
-    pub scale: [f32; 3],
-}
-
-fn default_scale() -> [f32; 3] {
-    [1.0, 1.0, 1.0]
-}
-
-// ── Per-object ─────────────────────────────────────────────────────────────────
-
-/// A single object entry in a scene file.
-///
-/// Supports both v1 (flat `position`/`rotation`/`scale`) and v2.x (nested
-/// `transform`) by merging: if `transform` is present its values win.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SceneObject {
-    /// Stable string identifier (unique within the scene).
-    pub id: String,
-
-    /// Human-readable name shown in the editor hierarchy.
-    pub name: String,
-
-    /// What kind of thing this is.
-    #[serde(deserialize_with = "deserialize_object_type")]
-    pub object_type: ObjectType,
-
-    // ── v2.x nested transform (takes priority when present) ───────────────────
-    #[serde(default)]
-    pub transform: SceneTransform,
-
-    // ── v1 flat fields (fallback if no nested transform) ─────────────────────
-    #[serde(default)]
-    pub position: [f32; 3],
-    #[serde(default)]
-    pub rotation: [f32; 3],
-    #[serde(default = "default_scale")]
-    pub scale: [f32; 3],
-
-    /// Parent object `id`, or `None` for root-level objects.
-    #[serde(default)]
-    pub parent: Option<String>,
-
-    /// Whether this object is rendered.
-    #[serde(default = "default_true")]
-    pub visible: bool,
-
-    /// Type-specific properties (material, light, etc.).
-    ///
-    /// ⚠ This field does NOT contain `__component_instances`.  Component data is
-    /// carried in the separate `component_instances` field below.
-    #[serde(default)]
-    pub props: HashMap<String, Value>,
-
-    /// Reflection-based component instances (v2.2+).
-    /// Falls back to `props["__component_instances"]` for older scene files.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub component_instances: Option<Value>,
-
-    // Editor-only fields — silently accepted and ignored at runtime.
-    #[serde(default, skip_serializing)]
-    pub locked: bool,
-    #[serde(default, skip_serializing)]
-    pub children: Value,
-    #[serde(default, skip_serializing)]
-    pub scene_path: Option<String>,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-impl Default for SceneObject {
-    fn default() -> Self {
-        Self {
-            id: String::new(),
-            name: String::new(),
-            object_type: ObjectType::Empty,
-            transform: SceneTransform::default(),
-            position: [0.0; 3],
-            rotation: [0.0; 3],
-            scale: [1.0, 1.0, 1.0],
-            parent: None,
-            visible: true,
-            props: HashMap::new(),
-            component_instances: None,
-            locked: false,
-            children: Value::Null,
-            scene_path: None,
-        }
-    }
-}
-
-/// Resolved world-space position — prefers nested `transform` over flat field.
-impl SceneObject {
-    pub fn world_position(&self) -> [f32; 3] {
-        // Nested transform is the v2.x format; the flat field is v1.
-        // If the nested transform has a non-zero position use it, otherwise
-        // fall back to the flat field.  (A v1 file never writes `transform`
-        // so its zero-value default is safe to skip.)
-        if self.transform.position != [0.0; 3] {
-            self.transform.position
-        } else {
-            self.position
-        }
-    }
-
-    pub fn world_rotation(&self) -> [f32; 3] {
-        if self.transform.rotation != [0.0; 3] {
-            self.transform.rotation
-        } else {
-            self.rotation
-        }
-    }
-
-    pub fn world_scale(&self) -> [f32; 3] {
-        // Default scale is [1,1,1] in both paths; prefer the nested one.
-        let ns = self.transform.scale;
-        if ns != [1.0, 1.0, 1.0] {
-            ns
-        } else {
-            // If both are default, just use the flat field (also [1,1,1]).
-            self.scale
-        }
-    }
-}
-
-// ── Object / mesh / light types ───────────────────────────────────────────────
-
-/// Broad category of a scene object.
-///
-/// Unknown variants (e.g. `"ParticleSystem"`) deserialize as `Unknown` so that
-/// the scene still loads even if the runtime doesn't support all editor types.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
-pub enum ObjectType {
-    Empty,
-    Folder,
-    Camera,
-    Mesh(MeshType),
-    Light(LightType),
-    /// Any type the runtime doesn't recognise.  Treated as `Empty` by the loader.
-    Unknown,
-}
-
-/// Custom deserializer for [`ObjectType`] that accepts both unit strings
-/// (`"Empty"`, `"ParticleSystem"`, …) and tagged objects
-/// (`{ "Mesh": "Cube" }`, `{ "Light": "Point" }`, …).
-fn deserialize_object_type<'de, D>(de: D) -> Result<ObjectType, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let v: Value = Value::deserialize(de)?;
-    Ok(object_type_from_value(&v))
-}
-
-fn object_type_from_value(v: &Value) -> ObjectType {
-    match v {
-        Value::String(s) => match s.as_str() {
-            "Empty" => ObjectType::Empty,
-            "Folder" => ObjectType::Folder,
-            "Camera" => ObjectType::Camera,
-            other => {
-                tracing::debug!(
-                    type_ = other,
-                    "Unknown ObjectType string — treating as Empty"
-                );
-                ObjectType::Unknown
-            }
-        },
-        Value::Object(map) => {
-            if let Some(mesh_val) = map.get("Mesh") {
-                let mt = mesh_type_from_value(mesh_val);
-                ObjectType::Mesh(mt)
-            } else if let Some(light_val) = map.get("Light") {
-                let lt = light_type_from_value(light_val);
-                ObjectType::Light(lt)
-            } else {
-                tracing::debug!(map = ?map, "Unknown tagged ObjectType map — treating as Empty");
-                ObjectType::Unknown
-            }
-        }
-        other => {
-            tracing::debug!(value = ?other, "Unexpected ObjectType JSON value — treating as Empty");
-            ObjectType::Unknown
-        }
-    }
-}
-
-fn mesh_type_from_value(v: &Value) -> MeshType {
-    match v.as_str().unwrap_or("") {
-        "Cube" => MeshType::Cube,
-        "Sphere" => MeshType::Sphere,
-        "Cylinder" => MeshType::Cylinder,
-        "Plane" => MeshType::Plane,
-        "Custom" => MeshType::Custom,
-        other => {
-            tracing::debug!(type_ = other, "Unknown MeshType — treating as Cube");
-            MeshType::Cube
-        }
-    }
-}
-
-fn light_type_from_value(v: &Value) -> LightType {
-    match v.as_str().unwrap_or("") {
-        "Directional" => LightType::Directional,
-        "Point" => LightType::Point,
-        "Spot" => LightType::Spot,
-        other => {
-            tracing::debug!(type_ = other, "Unknown LightType — treating as Point");
-            LightType::Point
-        }
-    }
-}
-
-// Manual Deserialize for ObjectType delegates to the custom fn above.
-impl<'de> Deserialize<'de> for ObjectType {
-    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let v: Value = Value::deserialize(de)?;
-        Ok(object_type_from_value(&v))
-    }
-}
-
-/// Built-in procedural mesh shapes.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MeshType {
-    Cube,
-    Sphere,
-    Cylinder,
-    Plane,
-    /// Custom asset; path provided in `props["asset_path"]`.
-    Custom,
-}
-
-/// Light kinds recognised by Helio.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LightType {
-    Directional,
-    Point,
-    Spot,
-}
-
-// ── Error type ─────────────────────────────────────────────────────────────────
-
-#[derive(Debug)]
-pub enum SceneLoadError {
-    Io(String),
-    Parse(String),
-}
-
-impl std::fmt::Display for SceneLoadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(e) => write!(f, "I/O error: {e}"),
-            Self::Parse(e) => write!(f, "Parse error: {e}"),
-        }
-    }
-}
-
-impl std::error::Error for SceneLoadError {}
-
-// ── Helper prop extractors ────────────────────────────────────────────────────
-
-impl SceneObject {
-    fn prop_f32(&self, key: &str, default: f32) -> f32 {
-        self.props
-            .get(key)
-            .and_then(|v| v.as_f64())
-            .map(|v| v as f32)
-            .unwrap_or(default)
-    }
-
-    fn prop_f32_arr3(&self, key: &str, default: [f32; 3]) -> [f32; 3] {
-        self.props
-            .get(key)
-            .and_then(|v| v.as_array())
-            .and_then(|a| {
-                if a.len() >= 3 {
-                    Some([
-                        a[0].as_f64().unwrap_or(0.0) as f32,
-                        a[1].as_f64().unwrap_or(0.0) as f32,
-                        a[2].as_f64().unwrap_or(0.0) as f32,
-                    ])
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(default)
-    }
-
-    fn prop_f32_arr4(&self, key: &str, default: [f32; 4]) -> [f32; 4] {
-        self.props
-            .get(key)
-            .and_then(|v| v.as_array())
-            .and_then(|a| {
-                if a.len() >= 4 {
-                    Some([
-                        a[0].as_f64().unwrap_or(0.0) as f32,
-                        a[1].as_f64().unwrap_or(0.0) as f32,
-                        a[2].as_f64().unwrap_or(0.0) as f32,
-                        a[3].as_f64().unwrap_or(1.0) as f32,
-                    ])
-                } else if a.len() == 3 {
-                    Some([
-                        a[0].as_f64().unwrap_or(0.0) as f32,
-                        a[1].as_f64().unwrap_or(0.0) as f32,
-                        a[2].as_f64().unwrap_or(0.0) as f32,
-                        1.0,
-                    ])
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(default)
-    }
-
-    // ── Reflection projection ────────────────────────────────────────────────
-
-    /// Return a copy of `props` with all component-instance data projected into
-    /// it via registered [`ScenePropsProjector`] implementations.
-    ///
-    /// This replaces manual field-name lookups into component data (e.g.
-    /// `data.get("mesh_asset")`) with the canonical reflection-based path so
-    /// that altering a component's field name only requires updating its
-    /// projector, not this scene-format module.
-    pub fn projected_props(&self) -> HashMap<String, Value> {
+impl SceneObjectRuntimeExt for SceneObject {
+    fn projected_props(&self) -> HashMap<String, Value> {
         let mut props = self.props.clone();
-        if let Some(instances) = self.component_instances() {
+        if let Some(instances) = component_instance_array(self) {
             for inst in instances {
                 if let Some(class_name) = inst.get("class_name").and_then(|v| v.as_str()) {
                     let component_data = inst.get("data");
@@ -463,168 +74,210 @@ impl SceneObject {
         props
     }
 
-    /// Helper: return the first component entry matching `class_name` from
-    /// the dedicated `component_instances` field, falling back to the legacy
-    /// `props["__component_instances"]` array.
-    fn component_instances(&self) -> Option<&Vec<Value>> {
-        self.component_instances
-            .as_ref()
-            .and_then(|v| v.as_array())
-            .or_else(|| {
-                self.props
-                    .get("__component_instances")
-                    .and_then(|v| v.as_array())
-            })
-    }
-
-    /// Return the `mesh_asset` path from this object's props or its
-    /// component instances, projected through the reflection system.
-    ///
-    /// This uses [`ScenePropsProjector`] registrations instead of hardcoded
-    /// field-name lookups into component data.
-    pub fn mesh_asset(&self) -> Option<String> {
-        let props = self.projected_props();
-        props
+    fn mesh_asset(&self) -> Option<String> {
+        self.projected_props()
             .get("mesh_asset")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty() && *s != "None")
             .map(String::from)
     }
 
-    // ── Material accessors ────────────────────────────────────────────────────
-
-    pub fn mat_base_color(&self) -> [f32; 4] {
-        self.prop_f32_arr4("base_color", [0.5, 0.5, 0.5, 1.0])
+    fn mat_base_color(&self) -> [f32; 4] {
+        prop_f32_arr4(&self.props, "base_color", [0.5, 0.5, 0.5, 1.0])
     }
-    pub fn mat_roughness(&self) -> f32 {
-        self.prop_f32("roughness", 0.5)
+    fn mat_roughness(&self) -> f32 {
+        prop_f32(&self.props, "roughness", 0.5)
     }
-    pub fn mat_metallic(&self) -> f32 {
-        self.prop_f32("metallic", 0.0)
+    fn mat_metallic(&self) -> f32 {
+        prop_f32(&self.props, "metallic", 0.0)
     }
-    pub fn mat_emissive(&self) -> [f32; 3] {
-        self.prop_f32_arr3("emissive", [0.0, 0.0, 0.0])
+    fn mat_emissive(&self) -> [f32; 3] {
+        prop_f32_arr3(&self.props, "emissive", [0.0, 0.0, 0.0])
     }
-    pub fn mat_emissive_strength(&self) -> f32 {
-        self.prop_f32("emissive_strength", 0.0)
+    fn mat_emissive_strength(&self) -> f32 {
+        prop_f32(&self.props, "emissive_strength", 0.0)
     }
 
-    // ── Light accessors ───────────────────────────────────────────────────────
-    //
-    // Uses projected props so that LightComponent data is reflected through
-    // the registered projector instead of manual field extraction.
-
-    pub fn light_color(&self) -> [f32; 3] {
-        let props = self.projected_props();
-        if let Some(v) = props.get("color") {
-            if let Some(a) = v.as_array() {
-                if a.len() >= 3 {
-                    return [
-                        a[0].as_f64().unwrap_or(1.0) as f32,
-                        a[1].as_f64().unwrap_or(1.0) as f32,
-                        a[2].as_f64().unwrap_or(1.0) as f32,
-                    ];
-                }
-            }
-        }
-        [1.0, 1.0, 1.0]
+    fn light_color(&self) -> [f32; 3] {
+        prop_f32_arr3(&self.projected_props(), "color", [1.0, 1.0, 1.0])
     }
-
-    pub fn light_intensity(&self) -> f32 {
-        let props = self.projected_props();
-        if let Some(v) = props.get("intensity").and_then(|v| v.as_f64()) {
-            return v as f32;
-        }
-        1.0
+    fn light_intensity(&self) -> f32 {
+        prop_f32(&self.projected_props(), "intensity", 1.0)
     }
-
-    pub fn light_range(&self) -> f32 {
-        let props = self.projected_props();
-        if let Some(v) = props.get("range").and_then(|v| v.as_f64()) {
-            return v as f32;
-        }
-        10.0
+    fn light_range(&self) -> f32 {
+        prop_f32(&self.projected_props(), "range", 10.0)
     }
-
-    pub fn light_inner_angle(&self) -> f32 {
-        let props = self.projected_props();
-        Self::prop_f32_from(&props, "inner_angle", 30.0)
+    fn light_inner_angle(&self) -> f32 {
+        prop_f32(&self.projected_props(), "inner_angle", 30.0)
     }
-    pub fn light_outer_angle(&self) -> f32 {
-        let props = self.projected_props();
-        Self::prop_f32_from(&props, "outer_angle", 45.0)
-    }
-
-    // ── Static helpers (no &self) ─────────────────────────────────────────────
-
-    fn prop_f32_from(props: &HashMap<String, Value>, key: &str, default: f32) -> f32 {
-        props
-            .get(key)
-            .and_then(|v| v.as_f64())
-            .map(|v| v as f32)
-            .unwrap_or(default)
+    fn light_outer_angle(&self) -> f32 {
+        prop_f32(&self.projected_props(), "outer_angle", 45.0)
     }
 }
 
+/// The object's component-instance array: the dedicated `component_instances`
+/// field, falling back to the legacy `props["__component_instances"]`.
+fn component_instance_array(obj: &SceneObject) -> Option<&Vec<Value>> {
+    obj.component_instances
+        .as_ref()
+        .and_then(|v| v.as_array())
+        .or_else(|| {
+            obj.props
+                .get("__component_instances")
+                .and_then(|v| v.as_array())
+        })
+}
+
+// ── Prop extraction helpers ───────────────────────────────────────────────────
+
+fn prop_f32(props: &HashMap<String, Value>, key: &str, default: f32) -> f32 {
+    props
+        .get(key)
+        .and_then(|v| v.as_f64())
+        .map(|v| v as f32)
+        .unwrap_or(default)
+}
+
+fn prop_f32_arr3(props: &HashMap<String, Value>, key: &str, default: [f32; 3]) -> [f32; 3] {
+    props
+        .get(key)
+        .and_then(|v| v.as_array())
+        .and_then(|a| {
+            if a.len() >= 3 {
+                Some([
+                    a[0].as_f64().unwrap_or(default[0] as f64) as f32,
+                    a[1].as_f64().unwrap_or(default[1] as f64) as f32,
+                    a[2].as_f64().unwrap_or(default[2] as f64) as f32,
+                ])
+            } else {
+                None
+            }
+        })
+        .unwrap_or(default)
+}
+
+fn prop_f32_arr4(props: &HashMap<String, Value>, key: &str, default: [f32; 4]) -> [f32; 4] {
+    props
+        .get(key)
+        .and_then(|v| v.as_array())
+        .and_then(|a| {
+            if a.len() >= 4 {
+                Some([
+                    a[0].as_f64().unwrap_or(0.0) as f32,
+                    a[1].as_f64().unwrap_or(0.0) as f32,
+                    a[2].as_f64().unwrap_or(0.0) as f32,
+                    a[3].as_f64().unwrap_or(1.0) as f32,
+                ])
+            } else if a.len() == 3 {
+                Some([
+                    a[0].as_f64().unwrap_or(0.0) as f32,
+                    a[1].as_f64().unwrap_or(0.0) as f32,
+                    a[2].as_f64().unwrap_or(0.0) as f32,
+                    1.0,
+                ])
+            } else {
+                None
+            }
+        })
+        .unwrap_or(default)
+}
+
 #[cfg(test)]
-mod blueprint_binding_tests {
-    //! #650 — the additive level-format extension for Blueprint class
-    //! bindings: old files load unchanged, new sections round-trip.
+mod tests {
+    //! Schema behaviour is verified in `pulsar_scene_format`'s own tests
+    //! (round-trip, v1/v2 backward compat, enum superset). What's left to
+    //! cover here is that the *runtime alias* really is that schema, and
+    //! that the extension trait still projects props the way the loader
+    //! expects.
 
     use super::*;
 
-    /// The additive guarantee: a pre-#650 file (no `blueprint_bindings` key)
-    /// deserializes with empty bindings.
+    /// The runtime's `SceneFile`/`SceneObject` are the canonical types, and a
+    /// v1 flat-transform file still opens through them.
     #[test]
-    fn old_files_without_bindings_load_unchanged() {
+    fn runtime_alias_is_the_canonical_schema() {
         let json = r#"{
-            "version": "2.1",
+            "version": 1,
             "objects": [
-                { "id": "cube", "name": "Cube", "object_type": {"Mesh": "Cube"}, "props": {} }
+                { "id": "ground", "name": "Ground", "object_type": {"Mesh": "Plane"},
+                  "position": [1.0, 2.0, 3.0], "scale": [10.0, 1.0, 10.0] }
             ]
         }"#;
-        let file: SceneFile = serde_json::from_str(json).expect("old file parses");
-        assert!(file.blueprint_bindings.is_empty());
-    }
-
-    /// A bindings section round-trips, keyed by StableId with per-instance
-    /// overrides; re-serializing drops the key when empty.
-    #[test]
-    fn bindings_round_trip_and_skip_serializing_when_empty() {
-        let json = r#"{
-            "version": "2.1",
-            "objects": [],
-            "blueprint_bindings": {
-                "lever_a": [
-                    { "class_name": "Lever", "overrides": { "speed": 7.5 } },
-                    { "class_name": "Alarm" }
-                ]
-            }
-        }"#;
-        let file: SceneFile = serde_json::from_str(json).expect("bindings parse");
-        let lever = &file.blueprint_bindings["lever_a"];
-        assert_eq!(lever.len(), 2, "multiple classes may bind to one object");
-        assert_eq!(lever[0].class_name, "Lever");
-        assert_eq!(lever[0].overrides.get("speed").and_then(Value::as_f64), Some(7.5));
-        assert!(lever[1].overrides.is_empty(), "missing overrides means defaults");
-
-        let rewritten = serde_json::to_string(&file).expect("serialize");
-        assert!(rewritten.contains("blueprint_bindings"), "non-empty section is written");
-        assert!(rewritten.contains(r#""overrides":{"speed":7.5}"#), "overrides survive");
-
-        let empty: SceneFile = serde_json::from_str(r#"{ "version": 1 }"#).unwrap();
-        assert!(
-            !serde_json::to_string(&empty).unwrap().contains("blueprint_bindings"),
-            "empty section stays out of the file (byte-compat with pre-#650 writers)"
+        let file: SceneFile = serde_json::from_str(json).expect("v1 parses");
+        let canonical: pulsar_scene_format::SceneFile =
+            serde_json::from_str(json).expect("v1 parses canonically");
+        assert_eq!(file.objects[0].world_position(), [1.0, 2.0, 3.0]);
+        assert_eq!(
+            file.objects[0].world_scale(),
+            canonical.objects[0].world_scale()
         );
     }
 
-    /// Bindings reference objects by StableId only — the type has no
-    /// name field to drift out of sync (#B2 identity rule).
+    /// Forward compatibility from the enum superset: the runtime now parses
+    /// object/light kinds it does not act on, rather than failing or
+    /// silently mislabelling them.
     #[test]
-    fn binding_type_carries_no_object_name() {
-        let binding: BlueprintBinding =
-            serde_json::from_str(r#"{ "class_name": "Enemy", "overrides": {} }"#).unwrap();
-        assert_eq!(binding.class_name, "Enemy");
+    fn runtime_accepts_editor_only_object_kinds() {
+        let json = r#"{
+            "version": "2.1",
+            "objects": [
+                { "id": "p", "name": "P", "object_type": "ParticleSystem" },
+                { "id": "l", "name": "L", "object_type": {"Light": "Area"} }
+            ]
+        }"#;
+        let file: SceneFile = serde_json::from_str(json).expect("superset parses");
+        assert_eq!(file.objects[0].object_type, ObjectType::ParticleSystem);
+        assert_eq!(file.objects[1].object_type, ObjectType::Light(LightType::Area));
+    }
+
+    /// The projected-prop accessors moved to a trait but kept their
+    /// behaviour: flat props are read directly, defaults apply when absent.
+    #[test]
+    fn extension_trait_reads_flat_props_and_defaults() {
+        let json = r#"{
+            "version": "2.1",
+            "objects": [
+                { "id": "a", "name": "A", "object_type": {"Mesh": "Cube"},
+                  "props": { "base_color": [0.1, 0.2, 0.3, 0.4], "roughness": 0.75,
+                             "color": [1.0, 0.5, 0.25], "intensity": 3.0 } },
+                { "id": "b", "name": "B", "object_type": {"Light": "Point"}, "props": {} }
+            ]
+        }"#;
+        let file: SceneFile = serde_json::from_str(json).expect("parses");
+
+        let a = &file.objects[0];
+        assert_eq!(a.mat_base_color(), [0.1, 0.2, 0.3, 0.4]);
+        assert_eq!(a.mat_roughness(), 0.75);
+        assert_eq!(a.light_color(), [1.0, 0.5, 0.25]);
+        assert_eq!(a.light_intensity(), 3.0);
+
+        let b = &file.objects[1];
+        assert_eq!(b.mat_base_color(), [0.5, 0.5, 0.5, 1.0]);
+        assert_eq!(b.mat_metallic(), 0.0);
+        assert_eq!(b.light_color(), [1.0, 1.0, 1.0]);
+        assert_eq!(b.light_range(), 10.0);
+        assert_eq!(b.light_outer_angle(), 45.0);
+        assert_eq!(b.mesh_asset(), None);
+    }
+
+    /// `mesh_asset` falls back to the legacy `props["__component_instances"]`
+    /// array when the dedicated field is absent.
+    #[test]
+    fn mesh_asset_reads_the_legacy_component_instances_key() {
+        let json = r#"{
+            "version": "2.1",
+            "objects": [
+                { "id": "a", "name": "A", "object_type": {"Mesh": "Custom"},
+                  "props": { "__component_instances": [
+                      { "class_name": "StaticMeshComponent", "data": { "mesh_asset": "models/a.mesh" } }
+                  ] } }
+            ]
+        }"#;
+        let file: SceneFile = serde_json::from_str(json).expect("parses");
+        // Whether the projector rewrites it or the raw prop survives, the
+        // legacy array is still the source that gets consulted.
+        assert!(file.objects[0]
+            .projected_props()
+            .contains_key("__component_instances"));
     }
 }

--- a/crates/subsystems/pulsar_scene/src/lib.rs
+++ b/crates/subsystems/pulsar_scene/src/lib.rs
@@ -18,29 +18,40 @@
 //! # Usage (editor / save)
 //!
 //! ```rust,ignore
-//! use pulsar_scene::{SceneFile, SceneObject, ObjectType, MeshType};
+//! use pulsar_scene::{SceneFile, SceneObject, SceneTransform, ObjectType, MeshType};
 //!
 //! let file = SceneFile {
-//!     version: 1,
+//!     version: serde_json::json!("2.1"),
 //!     objects: vec![
 //!         SceneObject {
 //!             id: "ground".into(),
 //!             name: "Ground".into(),
 //!             object_type: ObjectType::Mesh(MeshType::Plane),
-//!             scale: [10.0, 1.0, 10.0],
+//!             transform: SceneTransform { scale: [10.0, 1.0, 10.0], ..Default::default() },
 //!             ..Default::default()
 //!         },
 //!     ],
+//!     ..Default::default()
 //! };
 //! file.save(Path::new("scenes/default_level.json"))?;
 //! ```
+//!
+//! # Schema ownership (Pulsar-Native#557)
+//!
+//! The types below are **re-exports** of [`pulsar_scene_format`], the single
+//! canonical definition of the scene/level wire format. The editor's
+//! `LevelFile`/`SceneObjectData` are aliases of the very same types, so the
+//! two sides cannot drift. Runtime-only ergonomics (the projected-prop
+//! accessors) live on [`format::SceneObjectRuntimeExt`] here rather than on
+//! the schema type.
 
 pub mod format;
 pub mod loader;
 
 // Flatten the most-used types to the crate root.
 pub use format::{
-    BlueprintBinding, BlueprintBindings, LightType, MeshType, ObjectType, SceneFile,
-    SceneLoadError, SceneObject,
+    BlueprintBinding, BlueprintBindings, ComponentInstance, LevelEditorCameraState,
+    LevelEditorFileState, LevelMetadata, LightType, MeshType, ObjectType, SceneFile,
+    SceneLoadError, SceneObject, SceneObjectRuntimeExt, SceneTransform,
 };
 pub use loader::{build_transform_parts, component_instances_from_props, SceneLoader};

--- a/crates/subsystems/pulsar_scene_format/Cargo.toml
+++ b/crates/subsystems/pulsar_scene_format/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pulsar_scene_format"
+version = "0.1.0"
+edition = "2021"
+description = "Canonical on-disk scene/level file schema shared by the Pulsar editor and game runtime"
+publish = false
+
+# Deliberately dependency-light: this crate is depended on by BOTH the editor
+# (`ui_level_editor`, `engine_backend`) and the game runtime (`pulsar_scene`),
+# so it must not pull either side's graph in. serde + the virtual filesystem
+# is the whole surface.
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+engine_fs = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/subsystems/pulsar_scene_format/src/lib.rs
+++ b/crates/subsystems/pulsar_scene_format/src/lib.rs
@@ -1,0 +1,673 @@
+//! The canonical Pulsar scene/level file schema (Pulsar-Native#557, Phase B6).
+//!
+//! This crate owns **one** serde implementation of the `.level`/scene JSON
+//! wire format. Everything else aliases or re-exports it:
+//!
+//! | Consumer | Spelling |
+//! |---|---|
+//! | game runtime | `pulsar_scene::format::{SceneFile, SceneObject, …}` |
+//! | editor | `ui_level_editor::…::{LevelFile, SceneObjectData, …}` |
+//! | shared store | `engine_backend::scene::{ObjectType, LightType, MeshType, ComponentInstance}` |
+//!
+//! Before B6 the editor and the runtime each carried their own `#[derive(
+//! Serialize, Deserialize)]` of this shape, and they had already drifted
+//! (missing enum variants on one side, a v1 fallback only the other side
+//! modelled). One definition means that drift can no longer happen.
+//!
+//! # Placement
+//!
+//! The canonical types must not force editor crates to depend on the
+//! game-runtime crate (`pulsar_scene`, which pulls Helio) or vice versa, so
+//! they live here rather than in either. This crate's whole dependency set
+//! is serde + `engine_fs`'s virtual filesystem.
+//!
+//! # Format versions
+//!
+//! ## v2.x (editor output)
+//! - `version` is a string (e.g. `"2.1"`)
+//! - `transform` is a nested object: `{ "position": [...], "rotation": [...], "scale": [...] }`
+//! - Light `color`, `intensity`, `range` live directly in `props`
+//! - A `__component_instances` array in `props` may duplicate some data
+//!
+//! ## v1 (flat)
+//! - `version` is an integer (`1`)
+//! - `position`, `rotation`, `scale` are top-level fields on each object
+//!
+//! Both parse through [`SceneObject`]'s deserializer, which folds the v1 flat
+//! fields into the nested [`SceneTransform`] so every consumer sees one
+//! normalized in-memory shape (see [`SceneObject::world_position`]).
+//!
+//! # Leniency contract
+//!
+//! Deserialization is the **union** of what the two pre-B6 implementations
+//! accepted, never the intersection:
+//!
+//! - unrecognised `object_type` / `MeshType` / `LightType` spellings degrade
+//!   to `Empty` / `Cube` / `Point` instead of failing the parse, so a file
+//!   written by a newer editor still opens;
+//! - the editor-authored sections (`components`, `metadata`, `editor`,
+//!   `children`, `scene_path`) are parsed leniently — a malformed section is
+//!   dropped, never fatal;
+//! - every field except `id`, `name` and `object_type` has a default.
+//!
+//! Serialization matches the **editor's** output exactly (it is the only
+//! writer of level files in practice), field for field and attribute for
+//! attribute.
+
+use engine_fs::virtual_fs;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+
+// ── Ids ────────────────────────────────────────────────────────────────────
+
+/// Stable, editor-facing object identifier. Plain `String`; aliased as
+/// `EditorObjectId`/`ObjectId` by `engine_backend`.
+pub type ObjectId = String;
+
+// ── Top-level file ─────────────────────────────────────────────────────────
+
+/// An entire scene/level read from a scene file.
+///
+/// Aliased as `pulsar_scene::SceneFile` (game runtime) and
+/// `ui_level_editor::…::LevelFile` (editor).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SceneFile {
+    /// Format version — accepts both strings (`"2.1"`) and integers (`1`).
+    /// Read it through [`Self::version_string`] rather than matching on the
+    /// `Value` directly.
+    #[serde(default = "default_version_value")]
+    pub version: Value,
+
+    /// All objects in depth-first order (parents before children).
+    #[serde(default)]
+    pub objects: Vec<SceneObject>,
+
+    /// Reflection component instances keyed by object id.
+    ///
+    /// Parsed leniently (see [`deserialize_components`]): entries without a
+    /// `class_name` are skipped rather than failing the whole file, which is
+    /// the tolerance the runtime loader had before B6.
+    #[serde(default, deserialize_with = "deserialize_components")]
+    pub components: HashMap<ObjectId, Vec<ComponentInstance>>,
+
+    // ── Blueprint class bindings (#650) ───────────────────────────────────
+    /// Per-object Blueprint class bindings keyed by the object's **StableId**
+    /// ([`SceneObject::id`]), never its display name — so renaming an object
+    /// never orphans a binding. Multiple classes may bind to one object.
+    ///
+    /// Additive extension: older level files lack the key entirely and
+    /// deserialize to an empty map; files without bindings serialize without
+    /// it, staying byte-compatible with the pre-#650 format.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub blueprint_bindings: BlueprintBindings,
+
+    /// Authoring metadata. Absent (runtime-written) files get the default.
+    #[serde(default, deserialize_with = "deserialize_lenient")]
+    pub metadata: LevelMetadata,
+
+    /// Editor-only state persisted with the level (currently the camera).
+    #[serde(
+        default,
+        deserialize_with = "deserialize_lenient",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub editor: Option<LevelEditorFileState>,
+}
+
+fn default_version_value() -> Value {
+    Value::Number(1.into())
+}
+
+impl Default for SceneFile {
+    fn default() -> Self {
+        Self {
+            version: default_version_value(),
+            objects: Vec::new(),
+            components: HashMap::new(),
+            blueprint_bindings: BlueprintBindings::new(),
+            metadata: LevelMetadata::default(),
+            editor: None,
+        }
+    }
+}
+
+impl SceneFile {
+    /// Load a scene from a JSON file.
+    pub fn load(path: &std::path::Path) -> Result<Self, SceneLoadError> {
+        tracing::debug!(path = %path.display(), "Reading scene file from disk");
+        let bytes = virtual_fs::read_file(path).map_err(|e| SceneLoadError::Io(e.to_string()))?;
+        let text = String::from_utf8(bytes).map_err(|e| SceneLoadError::Io(e.to_string()))?;
+        tracing::debug!(bytes = text.len(), "Scene file read OK, parsing JSON");
+        let scene: Self =
+            serde_json::from_str(&text).map_err(|e| SceneLoadError::Parse(e.to_string()))?;
+        tracing::info!(
+            path = %path.display(),
+            version = %scene.version,
+            objects = scene.objects.len(),
+            "Scene file parsed"
+        );
+        Ok(scene)
+    }
+
+    /// Save a scene to a JSON file (pretty-printed).
+    pub fn save(&self, path: &std::path::Path) -> Result<(), SceneLoadError> {
+        if let Some(parent) = path.parent() {
+            virtual_fs::create_dir_all(parent).map_err(|e| SceneLoadError::Io(e.to_string()))?;
+        }
+        let text =
+            serde_json::to_string_pretty(self).map_err(|e| SceneLoadError::Parse(e.to_string()))?;
+        virtual_fs::write_file(path, text.as_bytes()).map_err(|e| SceneLoadError::Io(e.to_string()))
+    }
+
+    /// The `version` field as a string, whether it was written as a JSON
+    /// string (`"2.1"`, editor) or a number (`1`, v1 runtime files).
+    ///
+    /// Both load paths gate on this the same way: accept `1.x` and `2.x`.
+    pub fn version_string(&self) -> String {
+        match &self.version {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            other => other.to_string(),
+        }
+    }
+
+    /// Whether [`Self::version_string`] names a format this engine reads
+    /// (`1`, `1.x` or `2.x`).
+    pub fn is_supported_version(&self) -> bool {
+        let version = self.version_string();
+        version == "1" || version.starts_with("1.") || version.starts_with("2.")
+    }
+}
+
+// ── Component instances ────────────────────────────────────────────────────
+
+/// One reflection-based component instance attached to a scene object.
+///
+/// Re-exported as `engine_backend::scene::ComponentInstance`; it lives here
+/// because it is part of the level file's wire format (`components`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ComponentInstance {
+    /// Class name from the component registry (e.g. `"PhysicsComponent"`).
+    pub class_name: String,
+
+    /// Whether the component is active.
+    ///
+    /// Disabled components remain serialized but are ignored by scene-property
+    /// projection and behave as if they were absent.
+    #[serde(default = "default_component_enabled")]
+    pub enabled: bool,
+
+    /// Serialized component data, reconstructed via the registry on load.
+    pub data: Value,
+}
+
+fn default_component_enabled() -> bool {
+    true
+}
+
+/// Lenient parse of the `components` section:
+/// `{ "<object_id>": [ { "class_name": …, "data": …, "enabled": … } ] }`.
+///
+/// Entries missing a class name are skipped, non-array values are dropped and
+/// a missing `enabled` means enabled — preserving the tolerance the runtime
+/// level loader implemented by hand before B6, now that the field is typed
+/// rather than a raw `Value`.
+fn deserialize_components<'de, D>(
+    de: D,
+) -> Result<HashMap<ObjectId, Vec<ComponentInstance>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(de)?;
+    let mut out = HashMap::new();
+    let Some(map) = value.as_object() else {
+        return Ok(out);
+    };
+    for (object_id, entries) in map {
+        let Some(array) = entries.as_array() else {
+            continue;
+        };
+        let records = array
+            .iter()
+            .filter_map(|entry| {
+                Some(ComponentInstance {
+                    class_name: entry.get("class_name")?.as_str()?.to_string(),
+                    enabled: entry.get("enabled").and_then(Value::as_bool).unwrap_or(true),
+                    data: entry.get("data").cloned().unwrap_or(Value::Null),
+                })
+            })
+            .collect();
+        out.insert(object_id.clone(), records);
+    }
+    Ok(out)
+}
+
+/// Parse `T` through `serde_json::Value`, falling back to `T::default()`
+/// instead of failing the whole file.
+///
+/// Used for the editor-authored sections the runtime treated as opaque
+/// `Value` before B6 (`metadata`, `editor`): typing them must not make a
+/// previously-loadable file suddenly fail to parse.
+fn deserialize_lenient<'de, D, T>(de: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned + Default,
+{
+    let value = Value::deserialize(de)?;
+    Ok(serde_json::from_value(value).unwrap_or_default())
+}
+
+// ── Authoring metadata / editor state ──────────────────────────────────────
+
+/// When and by what the level was authored. Written by the editor; runtime
+/// writers leave it at its default.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct LevelMetadata {
+    #[serde(default)]
+    pub created: String,
+    #[serde(default)]
+    pub modified: String,
+    #[serde(default)]
+    pub editor_version: String,
+}
+
+/// The `editor` section: editor-only state that rides along with the level.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct LevelEditorFileState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub camera: Option<LevelEditorCameraState>,
+}
+
+/// Saved editor camera — position plus yaw/pitch in radians, the same
+/// convention `FreeCam::place` uses, so play mode can start where the editor
+/// view was.
+///
+/// Every field defaults: a truncated `"camera": {}` yields the origin rather
+/// than failing the level load.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct LevelEditorCameraState {
+    #[serde(default)]
+    pub position: [f32; 3],
+    #[serde(default)]
+    pub yaw: f32,
+    #[serde(default)]
+    pub pitch: f32,
+}
+
+// ── Blueprint class bindings (#650) ───────────────────────────────────────────
+
+/// One compiled-Blueprint class bound to one scene object (#650).
+///
+/// At play-mode load each binding becomes exactly one dispatcher instance
+/// whose component ops address the bound object's entity. The class must
+/// exist as compiled bytecode at
+/// `<project>/src/classes/<class_name>/events/.build/bytecode.json` — the
+/// same layout the generated `engine_main` auto-discovers.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlueprintBinding {
+    /// Compiled Blueprint class name — matches the bytecode's
+    /// `source_class` and the class directory under `<project>/src/classes/`.
+    pub class_name: String,
+
+    /// Per-instance variable overrides: variable name → JSON value in the
+    /// variable's natural JSON form (`7.5`, `"hello"`, `[1.0, 2.0]`, …).
+    /// Applied to this instance's state arena at spawn; variables not listed
+    /// keep their graph-authored defaults. Unknown names are ignored by the
+    /// dispatcher (the variable layout is the authority).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub overrides: HashMap<String, Value>,
+}
+
+/// A whole file's bindings: object StableId → that object's class bindings.
+///
+/// A `BTreeMap` so load-time spawning order is deterministic regardless of
+/// the JSON key order on disk.
+pub type BlueprintBindings = BTreeMap<ObjectId, Vec<BlueprintBinding>>;
+
+// ── Transform ─────────────────────────────────────────────────────────────────
+
+/// World-space transform stored as a nested object (editor v2.x format).
+///
+/// Aliased as the editor's `Transform`.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SceneTransform {
+    #[serde(default)]
+    pub position: [f32; 3],
+
+    /// Euler rotation in degrees, YXZ order (pitch, yaw, roll as stored by editor).
+    #[serde(default)]
+    pub rotation: [f32; 3],
+
+    #[serde(default = "default_scale")]
+    pub scale: [f32; 3],
+}
+
+impl Default for SceneTransform {
+    fn default() -> Self {
+        Self {
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0],
+            scale: default_scale(),
+        }
+    }
+}
+
+fn default_scale() -> [f32; 3] {
+    [1.0, 1.0, 1.0]
+}
+
+// ── Per-object ─────────────────────────────────────────────────────────────────
+
+/// A single object entry in a scene file.
+///
+/// Aliased as `pulsar_scene::SceneObject` (game runtime) and
+/// `ui_level_editor::SceneObjectData` (editor).
+///
+/// The v1 flat `position`/`rotation`/`scale` fields are **not** struct fields:
+/// they are folded into [`Self::transform`] on the deserialize path (see
+/// [`SceneObjectRepr`]), so in-memory state is always the normalized v2 shape
+/// and a v1 file that is loaded and re-saved keeps its transform instead of
+/// dropping it.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(from = "SceneObjectRepr")]
+pub struct SceneObject {
+    /// Stable string identifier (unique within the scene).
+    pub id: ObjectId,
+
+    /// Human-readable name shown in the editor hierarchy.
+    pub name: String,
+
+    /// What kind of thing this is.
+    pub object_type: ObjectType,
+
+    /// World-space transform (v1 flat fields already folded in).
+    pub transform: SceneTransform,
+
+    /// Whether this object is rendered.
+    pub visible: bool,
+
+    /// Whether the editor allows selecting/moving it.
+    pub locked: bool,
+
+    /// Parent object `id`, or `None` for root-level objects.
+    pub parent: Option<ObjectId>,
+
+    /// Direct children (populated by the editor's `SceneDatabase` on read,
+    /// ignored on write — the `parent` links are the authority).
+    pub children: Vec<ObjectId>,
+
+    /// Name-joined path from the root (`"Parent/Child"`), recomputed on read.
+    pub scene_path: String,
+
+    /// Type-specific properties (material, light, etc.).
+    ///
+    /// ⚠ This field does NOT contain `__component_instances`. Component data
+    /// is carried in [`Self::component_instances`] / the file's `components`
+    /// section; the key is only read as a fallback for older files.
+    #[serde(default)]
+    pub props: HashMap<String, Value>,
+
+    /// Reflection-based component instances (v2.2+).
+    /// Falls back to `props["__component_instances"]` for older scene files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component_instances: Option<Value>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for SceneObject {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            object_type: ObjectType::Empty,
+            transform: SceneTransform::default(),
+            visible: true,
+            locked: false,
+            parent: None,
+            children: Vec::new(),
+            scene_path: String::new(),
+            props: HashMap::new(),
+            component_instances: None,
+        }
+    }
+}
+
+impl SceneObject {
+    /// World-space position. v1 flat fields were folded into `transform` at
+    /// parse time, so this is simply the nested value.
+    pub fn world_position(&self) -> [f32; 3] {
+        self.transform.position
+    }
+
+    /// World-space Euler rotation in degrees (YXZ).
+    pub fn world_rotation(&self) -> [f32; 3] {
+        self.transform.rotation
+    }
+
+    /// World-space scale.
+    pub fn world_scale(&self) -> [f32; 3] {
+        self.transform.scale
+    }
+}
+
+/// Deserialize-side shape of [`SceneObject`], carrying the v1 flat transform
+/// fields alongside the v2 nested one.
+///
+/// The fold rule reproduces exactly what the runtime's `world_position()` /
+/// `world_rotation()` / `world_scale()` did before B6: a nested component
+/// that differs from its default wins, otherwise the flat field is used. That
+/// keeps files carrying *both* (never written by either tool, but tolerated)
+/// resolving identically, and makes a pure v1 file (`transform` absent, so
+/// defaulted) fall through to the flat fields wholesale.
+#[derive(Deserialize)]
+struct SceneObjectRepr {
+    id: ObjectId,
+    name: String,
+    object_type: ObjectType,
+
+    // ── v2.x nested transform (takes priority when present) ───────────────
+    #[serde(default)]
+    transform: SceneTransform,
+
+    // ── v1 flat fields (fallback when the nested one is at its default) ───
+    #[serde(default)]
+    position: [f32; 3],
+    #[serde(default)]
+    rotation: [f32; 3],
+    #[serde(default = "default_scale")]
+    scale: [f32; 3],
+
+    #[serde(default = "default_true")]
+    visible: bool,
+    #[serde(default, deserialize_with = "deserialize_lenient")]
+    locked: bool,
+    #[serde(default)]
+    parent: Option<ObjectId>,
+    #[serde(default, deserialize_with = "deserialize_lenient")]
+    children: Vec<ObjectId>,
+    #[serde(default, deserialize_with = "deserialize_lenient")]
+    scene_path: String,
+    #[serde(default)]
+    props: HashMap<String, Value>,
+    #[serde(default)]
+    component_instances: Option<Value>,
+}
+
+impl From<SceneObjectRepr> for SceneObject {
+    fn from(repr: SceneObjectRepr) -> Self {
+        let nested = repr.transform;
+        Self {
+            id: repr.id,
+            name: repr.name,
+            object_type: repr.object_type,
+            transform: SceneTransform {
+                position: if nested.position != [0.0; 3] {
+                    nested.position
+                } else {
+                    repr.position
+                },
+                rotation: if nested.rotation != [0.0; 3] {
+                    nested.rotation
+                } else {
+                    repr.rotation
+                },
+                scale: if nested.scale != default_scale() {
+                    nested.scale
+                } else {
+                    repr.scale
+                },
+            },
+            visible: repr.visible,
+            locked: repr.locked,
+            parent: repr.parent,
+            children: repr.children,
+            scene_path: repr.scene_path,
+            props: repr.props,
+            component_instances: repr.component_instances,
+        }
+    }
+}
+
+// ── Object / mesh / light types ───────────────────────────────────────────────
+
+/// Broad category of a scene object.
+///
+/// This is the **superset** of what the editor and the runtime each modelled
+/// before B6: the editor's full coverage (`ParticleSystem`/`AudioSource`/
+/// `Blueprint`) is canonical, and the runtime simply gains variants it may
+/// not act on yet — forward compatibility, not a regression.
+///
+/// Re-exported as `engine_backend::scene::ObjectType`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub enum ObjectType {
+    Empty,
+    Folder,
+    Camera,
+    Light(LightType),
+    Mesh(MeshType),
+    ParticleSystem,
+    AudioSource,
+    Blueprint,
+}
+
+/// Built-in procedural mesh shapes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeshType {
+    Cube,
+    Sphere,
+    Cylinder,
+    Plane,
+    /// Custom asset; path provided in `props["asset_path"]`.
+    Custom,
+}
+
+/// Light kinds recognised by Helio.
+///
+/// Includes `Area` (editor coverage) — the runtime ignores it for now.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LightType {
+    Directional,
+    Point,
+    Spot,
+    Area,
+}
+
+/// Lenient [`ObjectType`] deserialization: accepts unit strings (`"Empty"`,
+/// `"ParticleSystem"`, …) and tagged objects (`{ "Mesh": "Cube" }`,
+/// `{ "Light": "Point" }`, …), and degrades anything unrecognised to `Empty`
+/// rather than failing the parse, so a file written by a newer editor still
+/// opens in an older runtime.
+impl<'de> Deserialize<'de> for ObjectType {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let v: Value = Value::deserialize(de)?;
+        Ok(object_type_from_value(&v))
+    }
+}
+
+fn object_type_from_value(v: &Value) -> ObjectType {
+    match v {
+        Value::String(s) => match s.as_str() {
+            "Empty" => ObjectType::Empty,
+            "Folder" => ObjectType::Folder,
+            "Camera" => ObjectType::Camera,
+            "ParticleSystem" => ObjectType::ParticleSystem,
+            "AudioSource" => ObjectType::AudioSource,
+            "Blueprint" => ObjectType::Blueprint,
+            other => {
+                tracing::debug!(
+                    type_ = other,
+                    "Unknown ObjectType string — treating as Empty"
+                );
+                ObjectType::Empty
+            }
+        },
+        Value::Object(map) => {
+            if let Some(mesh_val) = map.get("Mesh") {
+                ObjectType::Mesh(mesh_type_from_value(mesh_val))
+            } else if let Some(light_val) = map.get("Light") {
+                ObjectType::Light(light_type_from_value(light_val))
+            } else {
+                tracing::debug!(map = ?map, "Unknown tagged ObjectType map — treating as Empty");
+                ObjectType::Empty
+            }
+        }
+        other => {
+            tracing::debug!(value = ?other, "Unexpected ObjectType JSON value — treating as Empty");
+            ObjectType::Empty
+        }
+    }
+}
+
+fn mesh_type_from_value(v: &Value) -> MeshType {
+    match v.as_str().unwrap_or("") {
+        "Cube" => MeshType::Cube,
+        "Sphere" => MeshType::Sphere,
+        "Cylinder" => MeshType::Cylinder,
+        "Plane" => MeshType::Plane,
+        "Custom" => MeshType::Custom,
+        other => {
+            tracing::debug!(type_ = other, "Unknown MeshType — treating as Cube");
+            MeshType::Cube
+        }
+    }
+}
+
+fn light_type_from_value(v: &Value) -> LightType {
+    match v.as_str().unwrap_or("") {
+        "Directional" => LightType::Directional,
+        "Point" => LightType::Point,
+        "Spot" => LightType::Spot,
+        "Area" => LightType::Area,
+        other => {
+            tracing::debug!(type_ = other, "Unknown LightType — treating as Point");
+            LightType::Point
+        }
+    }
+}
+
+// ── Error type ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum SceneLoadError {
+    Io(String),
+    Parse(String),
+}
+
+impl std::fmt::Display for SceneLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Parse(e) => write!(f, "Parse error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SceneLoadError {}
+
+#[cfg(test)]
+mod tests;

--- a/crates/subsystems/pulsar_scene_format/src/tests.rs
+++ b/crates/subsystems/pulsar_scene_format/src/tests.rs
@@ -1,0 +1,408 @@
+//! Verification for the canonical schema (Pulsar-Native#557, Phase B6).
+//!
+//! Three obligations, from the issue's own verification list:
+//!
+//! 1. **Round-trip** — a representative scene survives
+//!    serialize → deserialize unchanged.
+//! 2. **Backward compat** — a v2 nested-transform document *and* a true v1
+//!    flat-transform document both deserialize correctly. Because both the
+//!    editor's `LevelFile`/`SceneObjectData` and the runtime's
+//!    `SceneFile`/`SceneObject` are aliases of these types, passing here
+//!    means both consumers support both formats.
+//! 3. **Superset dispositions** — the editor's full `ObjectType` coverage and
+//!    `LightType::Area` parse, and unknown spellings still degrade instead of
+//!    failing.
+
+use super::*;
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+/// A v2.x document in exactly the shape the editor writes today: string
+/// version, nested `transform`, `children`/`scene_path`/`locked` present, a
+/// typed `components` section, `metadata`, and an `editor.camera`.
+const V2_NESTED: &str = r#"{
+    "version": "2.1",
+    "objects": [
+        {
+            "id": "sun", "name": "Sun", "object_type": {"Light": "Point"},
+            "transform": {"position": [1.0, 5.0, 2.0], "rotation": [10.0, 20.0, 30.0], "scale": [2.0, 2.0, 2.0]},
+            "visible": true, "locked": false, "parent": null,
+            "children": ["cube"], "scene_path": "Sun", "props": {"intensity": 4.0}
+        },
+        {
+            "id": "cube", "name": "Cube", "object_type": {"Mesh": "Cube"},
+            "transform": {"position": [0.0, 1.0, 0.0], "rotation": [0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0]},
+            "visible": true, "locked": true, "parent": "sun",
+            "children": [], "scene_path": "Sun/Cube", "props": {},
+            "component_instances": [{"class_name": "StaticMeshComponent", "data": {"mesh_asset": "a.mesh"}}]
+        }
+    ],
+    "components": {
+        "cube": [{"class_name": "StaticMeshComponent", "enabled": true, "data": {"mesh_asset": "a.mesh"}}]
+    },
+    "blueprint_bindings": {
+        "cube": [{"class_name": "Lever", "overrides": {"speed": 7.5}}]
+    },
+    "metadata": {"created": "2026-01-01T00:00:00Z", "modified": "2026-01-02T00:00:00Z", "editor_version": "0.1.0"},
+    "editor": {"camera": {"position": [3.0, 4.0, 5.0], "yaw": 0.5, "pitch": -0.25}}
+}"#;
+
+/// A **true v1** document: integer version, flat top-level `position`/
+/// `rotation`/`scale` per object, no nested `transform`, and none of the
+/// editor-only sections. Before B6 only the runtime type modelled this; the
+/// editor's own type did not, so this fixture is the regression guard for
+/// disposition 2 ("v1 flat-transform fallback is kept, on both consumers").
+const V1_FLAT: &str = r#"{
+    "version": 1,
+    "objects": [
+        {
+            "id": "ground", "name": "Ground", "object_type": {"Mesh": "Plane"},
+            "position": [1.0, 2.0, 3.0],
+            "rotation": [0.0, 90.0, 0.0],
+            "scale": [10.0, 1.0, 10.0],
+            "props": {"base_color": [0.2, 0.3, 0.4, 1.0]}
+        },
+        {
+            "id": "lamp", "name": "Lamp", "object_type": {"Light": "Spot"},
+            "position": [0.0, 5.0, 0.0]
+        }
+    ]
+}"#;
+
+// ── 1. Round-trip ──────────────────────────────────────────────────────────
+
+#[test]
+fn representative_scene_round_trips() {
+    let original: SceneFile = serde_json::from_str(V2_NESTED).expect("fixture parses");
+    let text = serde_json::to_string(&original).expect("serialize");
+    let again: SceneFile = serde_json::from_str(&text).expect("re-parse");
+
+    assert_eq!(again.version_string(), "2.1");
+    assert_eq!(again.objects.len(), original.objects.len());
+    for (a, b) in original.objects.iter().zip(&again.objects) {
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.object_type, b.object_type);
+        assert_eq!(a.transform, b.transform);
+        assert_eq!(a.visible, b.visible);
+        assert_eq!(a.locked, b.locked);
+        assert_eq!(a.parent, b.parent);
+        assert_eq!(a.children, b.children);
+        assert_eq!(a.scene_path, b.scene_path);
+        assert_eq!(a.props, b.props);
+        assert_eq!(a.component_instances, b.component_instances);
+    }
+    assert_eq!(again.blueprint_bindings, original.blueprint_bindings);
+    assert_eq!(again.metadata.created, original.metadata.created);
+    assert_eq!(again.metadata.modified, original.metadata.modified);
+    assert_eq!(again.metadata.editor_version, original.metadata.editor_version);
+    assert_eq!(
+        again.editor.as_ref().and_then(|e| e.camera),
+        original.editor.as_ref().and_then(|e| e.camera),
+    );
+
+    let cube_components = &again.components["cube"];
+    assert_eq!(cube_components.len(), 1);
+    assert_eq!(cube_components[0].class_name, "StaticMeshComponent");
+    assert!(cube_components[0].enabled);
+    assert_eq!(cube_components[0].data["mesh_asset"], "a.mesh");
+}
+
+// ── 2. Backward compatibility ──────────────────────────────────────────────
+
+#[test]
+fn v2_nested_transform_document_loads() {
+    let file: SceneFile = serde_json::from_str(V2_NESTED).expect("v2 parses");
+    assert!(file.is_supported_version());
+
+    let sun = &file.objects[0];
+    assert_eq!(sun.object_type, ObjectType::Light(LightType::Point));
+    assert_eq!(sun.world_position(), [1.0, 5.0, 2.0]);
+    assert_eq!(sun.world_rotation(), [10.0, 20.0, 30.0]);
+    assert_eq!(sun.world_scale(), [2.0, 2.0, 2.0]);
+    assert_eq!(sun.children, vec!["cube".to_string()]);
+    assert_eq!(sun.scene_path, "Sun");
+    assert!(!sun.locked);
+
+    let cube = &file.objects[1];
+    assert_eq!(cube.object_type, ObjectType::Mesh(MeshType::Cube));
+    assert_eq!(cube.parent.as_deref(), Some("sun"));
+    assert!(cube.locked);
+    assert!(cube.component_instances.is_some());
+
+    let camera = file.editor.and_then(|e| e.camera).expect("camera present");
+    assert_eq!(camera.position, [3.0, 4.0, 5.0]);
+    assert_eq!(camera.yaw, 0.5);
+    assert_eq!(camera.pitch, -0.25);
+}
+
+#[test]
+fn v1_flat_transform_document_loads_on_both_consumers() {
+    let file: SceneFile = serde_json::from_str(V1_FLAT).expect("v1 parses");
+    assert_eq!(file.version_string(), "1");
+    assert!(file.is_supported_version());
+
+    // The flat fields are folded into the nested transform, so the v1 file
+    // reads back through exactly the same accessors a v2 file does.
+    let ground = &file.objects[0];
+    assert_eq!(ground.world_position(), [1.0, 2.0, 3.0]);
+    assert_eq!(ground.world_rotation(), [0.0, 90.0, 0.0]);
+    assert_eq!(ground.world_scale(), [10.0, 1.0, 10.0]);
+    assert_eq!(ground.transform.position, [1.0, 2.0, 3.0]);
+    assert_eq!(ground.object_type, ObjectType::Mesh(MeshType::Plane));
+
+    // Absent optional fields take the documented defaults.
+    let lamp = &file.objects[1];
+    assert_eq!(lamp.world_position(), [0.0, 5.0, 0.0]);
+    assert_eq!(lamp.world_scale(), [1.0, 1.0, 1.0], "scale defaults to unit");
+    assert!(lamp.visible, "visible defaults to true");
+    assert!(!lamp.locked);
+    assert_eq!(lamp.parent, None);
+    assert!(lamp.children.is_empty());
+    assert_eq!(lamp.scene_path, "");
+    assert!(lamp.props.is_empty());
+
+    // Editor-only sections are absent, not fatal.
+    assert!(file.components.is_empty());
+    assert!(file.blueprint_bindings.is_empty());
+    assert_eq!(file.metadata.created, "");
+    assert!(file.editor.is_none());
+}
+
+#[test]
+fn a_v1_file_that_is_loaded_and_re_saved_keeps_its_transform() {
+    // Before B6 the flat fields lived on the struct alongside an all-default
+    // nested `transform`, so a load/save cycle serialized both and the
+    // "which wins" rule had to be re-applied by every reader. Folding at
+    // parse time means the re-saved file is plain v2.
+    let file: SceneFile = serde_json::from_str(V1_FLAT).expect("v1 parses");
+    let text = serde_json::to_string(&file).expect("serialize");
+    let again: SceneFile = serde_json::from_str(&text).expect("re-parse");
+    assert_eq!(again.objects[0].world_position(), [1.0, 2.0, 3.0]);
+    assert_eq!(again.objects[0].world_scale(), [10.0, 1.0, 10.0]);
+
+    // The re-saved object carries only the nested `transform`: the flat keys
+    // are a deserialize-only fallback, never re-emitted.
+    let raw: Value = serde_json::from_str(&text).expect("valid json");
+    let object = raw["objects"][0].as_object().expect("object");
+    assert!(object.contains_key("transform"));
+    for flat in ["position", "rotation", "scale"] {
+        assert!(!object.contains_key(flat), "`{flat}` must not be re-emitted");
+    }
+}
+
+#[test]
+fn nested_transform_wins_over_flat_fields_when_both_are_present() {
+    // The pre-B6 `world_position()`/`world_rotation()`/`world_scale()` rule,
+    // preserved verbatim: a non-default nested component wins, otherwise the
+    // flat field is used.
+    let json = r#"{
+        "version": "2.1",
+        "objects": [{
+            "id": "x", "name": "X", "object_type": "Empty",
+            "transform": {"position": [9.0, 9.0, 9.0], "rotation": [0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0]},
+            "position": [1.0, 1.0, 1.0], "rotation": [4.0, 5.0, 6.0], "scale": [7.0, 7.0, 7.0]
+        }]
+    }"#;
+    let file: SceneFile = serde_json::from_str(json).expect("parses");
+    let obj = &file.objects[0];
+    assert_eq!(obj.world_position(), [9.0, 9.0, 9.0], "nested position wins");
+    assert_eq!(obj.world_rotation(), [4.0, 5.0, 6.0], "default nested rotation yields to flat");
+    assert_eq!(obj.world_scale(), [7.0, 7.0, 7.0], "default nested scale yields to flat");
+}
+
+// ── 3. Superset dispositions ───────────────────────────────────────────────
+
+#[test]
+fn object_type_covers_the_editor_superset() {
+    let json = r#"{
+        "version": "2.1",
+        "objects": [
+            {"id": "a", "name": "A", "object_type": "ParticleSystem"},
+            {"id": "b", "name": "B", "object_type": "AudioSource"},
+            {"id": "c", "name": "C", "object_type": "Blueprint"},
+            {"id": "d", "name": "D", "object_type": {"Light": "Area"}},
+            {"id": "e", "name": "E", "object_type": "Folder"},
+            {"id": "f", "name": "F", "object_type": "Camera"}
+        ]
+    }"#;
+    let file: SceneFile = serde_json::from_str(json).expect("superset parses");
+    let types: Vec<ObjectType> = file.objects.iter().map(|o| o.object_type).collect();
+    assert_eq!(
+        types,
+        vec![
+            ObjectType::ParticleSystem,
+            ObjectType::AudioSource,
+            ObjectType::Blueprint,
+            ObjectType::Light(LightType::Area),
+            ObjectType::Folder,
+            ObjectType::Camera,
+        ]
+    );
+
+    // …and every one of them survives a round-trip through the wire format.
+    let text = serde_json::to_string(&file).expect("serialize");
+    let again: SceneFile = serde_json::from_str(&text).expect("re-parse");
+    assert_eq!(
+        again.objects.iter().map(|o| o.object_type).collect::<Vec<_>>(),
+        types
+    );
+    assert!(text.contains(r#""object_type":"ParticleSystem""#));
+    assert!(text.contains(r#""object_type":{"Light":"Area"}"#));
+}
+
+#[test]
+fn unrecognised_type_spellings_degrade_instead_of_failing() {
+    let json = r#"{
+        "version": "2.1",
+        "objects": [
+            {"id": "a", "name": "A", "object_type": "SomethingFromTheFuture"},
+            {"id": "b", "name": "B", "object_type": {"Mesh": "Torus"}},
+            {"id": "c", "name": "C", "object_type": {"Light": "Volumetric"}},
+            {"id": "d", "name": "D", "object_type": {"Nonsense": 3}},
+            {"id": "e", "name": "E", "object_type": 42}
+        ]
+    }"#;
+    let file: SceneFile = serde_json::from_str(json).expect("unknown types never fail the parse");
+    assert_eq!(file.objects[0].object_type, ObjectType::Empty);
+    assert_eq!(file.objects[1].object_type, ObjectType::Mesh(MeshType::Cube));
+    assert_eq!(file.objects[2].object_type, ObjectType::Light(LightType::Point));
+    assert_eq!(file.objects[3].object_type, ObjectType::Empty);
+    assert_eq!(file.objects[4].object_type, ObjectType::Empty);
+}
+
+// ── Leniency of the editor-authored sections ───────────────────────────────
+
+#[test]
+fn malformed_editor_sections_are_dropped_not_fatal() {
+    // The runtime carried these as opaque `Value`s before B6; typing them
+    // must not turn a previously-loadable file into a parse error.
+    let json = r#"{
+        "version": "2.1",
+        "objects": [],
+        "components": {"x": [{"data": {}}, {"class_name": "Ok", "data": {}}], "y": 5},
+        "metadata": "not an object",
+        "editor": 12
+    }"#;
+    let file: SceneFile = serde_json::from_str(json).expect("lenient sections");
+    assert_eq!(file.components["x"].len(), 1, "class_name-less entry skipped");
+    assert_eq!(file.components["x"][0].class_name, "Ok");
+    assert!(file.components["x"][0].enabled, "missing `enabled` means enabled");
+    assert!(!file.components.contains_key("y"), "non-array entry dropped");
+    assert_eq!(file.metadata.created, "");
+    assert!(file.editor.is_none());
+}
+
+#[test]
+fn component_enabled_flag_round_trips() {
+    let json = r#"{
+        "version": "2.1", "objects": [],
+        "components": {"x": [{"class_name": "A", "enabled": false, "data": {"v": 1}}]}
+    }"#;
+    let file: SceneFile = serde_json::from_str(json).expect("parses");
+    assert!(!file.components["x"][0].enabled);
+    let again: SceneFile = serde_json::from_str(&serde_json::to_string(&file).unwrap()).unwrap();
+    assert!(!again.components["x"][0].enabled);
+    assert_eq!(again.components["x"][0].data["v"], 1);
+}
+
+// ── Blueprint class bindings (#650) ────────────────────────────────────────
+//
+// Moved verbatim from `pulsar_scene::format`'s own test module when that
+// module became a re-export of this crate.
+
+/// The additive guarantee: a pre-#650 file (no `blueprint_bindings` key)
+/// deserializes with empty bindings.
+#[test]
+fn old_files_without_bindings_load_unchanged() {
+    let json = r#"{
+        "version": "2.1",
+        "objects": [
+            { "id": "cube", "name": "Cube", "object_type": {"Mesh": "Cube"}, "props": {} }
+        ]
+    }"#;
+    let file: SceneFile = serde_json::from_str(json).expect("old file parses");
+    assert!(file.blueprint_bindings.is_empty());
+}
+
+/// A bindings section round-trips, keyed by StableId with per-instance
+/// overrides; re-serializing drops the key when empty.
+#[test]
+fn bindings_round_trip_and_skip_serializing_when_empty() {
+    let json = r#"{
+        "version": "2.1",
+        "objects": [],
+        "blueprint_bindings": {
+            "lever_a": [
+                { "class_name": "Lever", "overrides": { "speed": 7.5 } },
+                { "class_name": "Alarm" }
+            ]
+        }
+    }"#;
+    let file: SceneFile = serde_json::from_str(json).expect("bindings parse");
+    let lever = &file.blueprint_bindings["lever_a"];
+    assert_eq!(lever.len(), 2, "multiple classes may bind to one object");
+    assert_eq!(lever[0].class_name, "Lever");
+    assert_eq!(lever[0].overrides.get("speed").and_then(Value::as_f64), Some(7.5));
+    assert!(lever[1].overrides.is_empty(), "missing overrides means defaults");
+
+    let rewritten = serde_json::to_string(&file).expect("serialize");
+    assert!(rewritten.contains("blueprint_bindings"), "non-empty section is written");
+    assert!(rewritten.contains(r#""overrides":{"speed":7.5}"#), "overrides survive");
+
+    let empty: SceneFile = serde_json::from_str(r#"{ "version": 1 }"#).unwrap();
+    assert!(
+        !serde_json::to_string(&empty).unwrap().contains("blueprint_bindings"),
+        "empty section stays out of the file (byte-compat with pre-#650 writers)"
+    );
+}
+
+/// Bindings reference objects by StableId only — the type has no
+/// name field to drift out of sync (#B2 identity rule).
+#[test]
+fn binding_type_carries_no_object_name() {
+    let binding: BlueprintBinding =
+        serde_json::from_str(r#"{ "class_name": "Enemy", "overrides": {} }"#).unwrap();
+    assert_eq!(binding.class_name, "Enemy");
+}
+
+// ── Wire-shape guards ──────────────────────────────────────────────────────
+
+#[test]
+fn editor_written_keys_are_all_emitted() {
+    // Regression guard for the merge itself: the runtime type used to mark
+    // `components`/`metadata`/`editor`/`locked`/`children`/`scene_path` as
+    // `skip_serializing`. Now that both consumers share one type, a save from
+    // either side must still produce the editor's full document.
+    let file: SceneFile = serde_json::from_str(V2_NESTED).expect("parses");
+    let text = serde_json::to_string(&file).expect("serialize");
+    for key in [
+        "version",
+        "objects",
+        "components",
+        "blueprint_bindings",
+        "metadata",
+        "editor",
+        "object_type",
+        "transform",
+        "visible",
+        "locked",
+        "parent",
+        "children",
+        "scene_path",
+        "props",
+        "component_instances",
+    ] {
+        assert!(text.contains(&format!("\"{key}\"")), "`{key}` must be written");
+    }
+}
+
+#[test]
+fn component_instances_is_omitted_when_absent() {
+    let file: SceneFile = serde_json::from_str(V1_FLAT).expect("parses");
+    let text = serde_json::to_string(&file).expect("serialize");
+    assert!(
+        !text.contains("component_instances"),
+        "None must stay out of the file"
+    );
+}


### PR DESCRIPTION
Phase B6's last unchecked box. Implements the design decision in the final comment on #557.

## What changed

The editor's `LevelFile`/`SceneObjectData` and the game runtime's `SceneFile`/`SceneObject` each carried their own `#[derive(Serialize, Deserialize)]` of the same `.level` JSON. There is now exactly **one** definition, and both sides are thin aliases of it.

**Canonical type lives in a new crate: `crates/subsystems/pulsar_scene_format`.**

Placement rationale: a new crate rather than promoting `pulsar_scene::format`, because the canonical types must not drag the editor into the game-runtime crate's graph (Helio, `helio_component`, glam) nor the reverse. The new crate depends only on `serde`, `serde_json`, `tracing` and `engine_fs`'s virtual filesystem.

| Consumer | Spelling |
|---|---|
| game runtime | `pulsar_scene::format::{SceneFile, SceneObject, …}` — re-exports |
| editor | `ui_level_editor::…::{LevelFile, SceneObjectData, Transform, LevelMetadata, …}` — `pub type` aliases |
| shared store | `engine_backend::scene::{ObjectType, LightType, MeshType, ComponentInstance, EditorObjectId}` — re-exports |

## Dispositions implemented

**1. Unification level — JSON type only.** `SceneLoader` keeps its by-design one-shot, `World`-free dispatch into the renderer. Nothing here gives it a `pulsar_scenedb::World` dependency.

**2. Enum coverage — superset.** `ObjectType` keeps the editor's full coverage (`ParticleSystem`/`AudioSource`/`Blueprint`); `LightType` keeps `Area`. Because both sides now name the *same* type, `runtime_level.rs`'s hand-written `FileObjectType -> ObjectType` translation table is deleted outright.

`ObjectType::Unknown` went with it: the canonical deserializer degrades unrecognised spellings straight to `Empty` (and `Cube`/`Point` for unknown mesh/light kinds), which is exactly what every consumer already collapsed `Unknown` to (`FileObjectType::Empty | FileObjectType::Unknown => ObjectType::Empty` was its only match site).

**3. v1 flat transform — kept, on the deserialize path.** `position`/`rotation`/`scale` are no longer struct fields. A private `SceneObjectRepr` folds them into the nested `transform` using the pre-B6 `world_position()`/`world_rotation()`/`world_scale()` rule *verbatim* — a non-default nested component wins, otherwise the flat field. Consequences:

- the editor's load path gains real v1 support (it had none before);
- in-memory state is always the normalized v2 shape;
- a v1 file loaded and re-saved keeps its transform instead of writing zeros, which the old shape (flat fields alongside an all-default `transform`, both serialized) did not guarantee.

**4. Projected-prop accessors — not schema.** `mat_base_color`/`mat_roughness`/`mat_metallic`/`mat_emissive`/`mat_emissive_strength`/`light_color`/`light_intensity`/`light_range`/`light_inner_angle`/`light_outer_angle`/`mesh_asset`/`projected_props` move to `SceneObjectRuntimeExt`, an extension trait defined in `pulsar_scene::format` and implemented on the canonical type. They need `pulsar_reflection`, which the schema crate deliberately does not depend on; the editor never sees them. (They had zero call sites outside `format.rs` itself, so nothing had to change.)

## One reconciliation beyond the four dispositions

Merging the two types also meant reconciling the sections the runtime modelled as opaque `serde_json::Value` with `skip_serializing`, while the editor modelled them typed and *wrote* them: `components`, `metadata`, `editor`, and per-object `locked`/`children`/`scene_path`.

This is not a wire-level incompatibility (both sides read the same bytes; the runtime's view was simply lossy), so it did not warrant stopping — but it is worth flagging in review. The canonical type takes the **editor's typed, always-written shape** (the editor is the only writer of level files in practice — `SceneFile::save` has no production callers) plus the **runtime's tolerance**:

- `components: HashMap<ObjectId, Vec<ComponentInstance>>` with a lenient deserializer — entries without a `class_name` are skipped, non-array values dropped, a missing `enabled` means enabled. That is precisely what `runtime_level::persisted_components` did by hand; that function is deleted in favour of the schema doing it once.
- `metadata` gained a default, so a runtime- or hand-authored file without it now opens in the editor (it used to be a required field — strictly more permissive).
- `editor`/`editor.camera` are typed with every field defaulted, so a truncated `"camera": {}` yields the origin rather than failing the load. (Behaviour delta: the old runtime helper returned `None` for a camera with no `position`; it now yields `[0,0,0]`. No writer produces that shape.)
- `version` is a `serde_json::Value` so it round-trips both the editor's `"2.1"` string and v1's bare `1`. Both load paths now share `version_string()` / `is_supported_version()` instead of two hand-rolled gates.
- `ComponentInstance` and `EditorObjectId` move from `engine_backend::scene::metadata` into the schema crate (they *are* wire-format types) and are re-exported from their old paths, so no call site changed.

Emitted bytes for an editor save are unchanged.

## The `[patch."…/Pulsar-Reflection"]` block: **reverted, kept in place**

Deleting it breaks resolution exactly as anticipated, so per the task's own instruction it was restored (with a comment recording why). What conflicts:

`pulsar_scenedb` (SceneDB, itself a patched git dep) depends on `pulsar_reflection` at rev **`b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff`**, not at the workspace pin `745ee787cc63288463c170aafb778672db8e85ac`. With the `[patch]` block gone, Cargo resolves **two** `pulsar_reflection` packages into the graph — splitting the reflection registry types exchanged across the SceneDB/Helio seam. Verbatim from the `Cargo.lock` diff produced by the deletion:

```
+[[package]]
+name = "pulsar_reflection"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection?rev=b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff#b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff"
```
```
 name = "pulsar_scenedb"
-  "pulsar_reflection",
+  "pulsar_reflection 0.1.0 (git+…?rev=b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff)",
```

So the two stated trigger conditions (Pulsar-Reflection `main` == the pinned rev; SceneDB#45 closed) are necessary but not sufficient — SceneDB's *own* `pulsar_reflection` dependency has to repin to `745ee787…` first. The block now carries a comment saying exactly that.

With the block kept, the graph has exactly one:

```
$ cargo tree --workspace -i pulsar_reflection --depth 0
pulsar_reflection v0.1.0 (https://github.com/Far-Beyond-Pulsar//Pulsar-Reflection?rev=745ee787cc63288463c170aafb778672db8e85ac#745ee787)
$ grep -c '^name = "pulsar_reflection"$' Cargo.lock
1
```

## Pre-existing `main` breakage fixed to make this verifiable (commit 1)

`cargo check --workspace --exclude pulsar_docs --all-targets` — CI's exact command — **could not resolve on `main`**. Two automated dependency bumps had landed without a matching `Cargo.lock` refresh, so nothing exercised them until the lock next needed re-resolving (which adding a workspace member forces):

1. `c760bd500` bumped `rapier3d` 0.34 → 0.35, but 0.35 **removed** the `simd-stable` feature the workspace requests:
   ```
   error: failed to select a version for `rapier3d`.
   package `engine_backend` depends on `rapier3d` with feature `simd-stable`
   but `rapier3d` does not have that feature
   ```
   Pinned back to `0.34.0` — what `Cargo.lock` already held. **Re-do this bump deliberately**, choosing the 0.35 replacement for `simd-stable` (`simd8`, or plain defaults).
2. `pulsar_docs` requested `prettyplease = "0.3"` while parsing with the workspace's `syn` 2.x. prettyplease 0.3 takes `syn` 3.0 types, so both syn majors landed in the build graph and the build script stopped compiling (`expected syn::file::File, found syn::File`). Pinned to `"0.2"` — the version `Cargo.lock` had been resolving all along.

Both are unrelated to the schema work and are isolated in their own commit.

## Verification

```
$ cargo check --workspace --exclude pulsar_docs --all-targets
=== EXIT: 0 ===
```

```
$ cargo test -p pulsar_scene_format
running 14 tests
test tests::binding_type_carries_no_object_name ... ok
test tests::v1_flat_transform_document_loads_on_both_consumers ... ok
test tests::malformed_editor_sections_are_dropped_not_fatal ... ok
test tests::old_files_without_bindings_load_unchanged ... ok
test tests::nested_transform_wins_over_flat_fields_when_both_are_present ... ok
test tests::unrecognised_type_spellings_degrade_instead_of_failing ... ok
test tests::component_enabled_flag_round_trips ... ok
test tests::bindings_round_trip_and_skip_serializing_when_empty ... ok
test tests::component_instances_is_omitted_when_absent ... ok
test tests::v2_nested_transform_document_loads ... ok
test tests::editor_written_keys_are_all_emitted ... ok
test tests::a_v1_file_that_is_loaded_and_re_saved_keeps_its_transform ... ok
test tests::object_type_covers_the_editor_superset ... ok
test tests::representative_scene_round_trips ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```
$ cargo test -p pulsar_scene
running 5 tests
test format::tests::runtime_accepts_editor_only_object_kinds ... ok
test format::tests::runtime_alias_is_the_canonical_schema ... ok
test format::tests::extension_trait_reads_flat_props_and_defaults ... ok
test loader::tests::shared_scene_loader_links_planet_terrain_runtime_behavior ... ok
test format::tests::mesh_asset_reads_the_legacy_component_instances_key ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```
$ cargo test -p ui_level_editor --lib
test result: ok. 50 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
(includes `blueprint_bindings_preservation_tests::saving_preserves_an_authored_bindings_section` and `::loading_a_bound_level_succeeds_and_ignores_the_section_for_now` — the editor save/load round-trip through the new aliases)

```
$ cargo test -p engine_backend --lib
test result: ok. 85 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
(includes all of `scene::runtime_level::tests` — the runtime level-load path)

```
$ cargo test -p pulsar_game --lib
test result: ok. 81 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

**No duplicate serde definitions remain.** Every schema type resolves to exactly one definition site:

```
$ grep -rn "pub struct SceneObject\b\|pub struct SceneObjectData\|pub struct SceneFile\|pub struct LevelFile\|pub struct SceneTransform\|pub struct LevelMetadata\|pub enum ObjectType\|pub enum LightType\|pub enum MeshType\|pub struct ComponentInstance\|pub struct BlueprintBinding" --include=*.rs crates plugins tools
crates/subsystems/pulsar_scene_format/src/lib.rs:76:pub struct SceneFile {
crates/subsystems/pulsar_scene_format/src/lib.rs:191:pub struct ComponentInstance {
crates/subsystems/pulsar_scene_format/src/lib.rs:267:pub struct LevelMetadata {
crates/subsystems/pulsar_scene_format/src/lib.rs:278:pub struct LevelEditorFileState {
crates/subsystems/pulsar_scene_format/src/lib.rs:290:pub struct LevelEditorCameraState {
crates/subsystems/pulsar_scene_format/src/lib.rs:309:pub struct BlueprintBinding {
crates/subsystems/pulsar_scene_format/src/lib.rs:335:pub struct SceneTransform {
crates/subsystems/pulsar_scene_format/src/lib.rs:375:pub struct SceneObject {
crates/subsystems/pulsar_scene_format/src/lib.rs:547:pub enum ObjectType {
crates/subsystems/pulsar_scene_format/src/lib.rs:560:pub enum MeshType {
crates/subsystems/pulsar_scene_format/src/lib.rs:573:pub enum LightType {
```
(plus `shader_editor`'s unrelated shader-preview-primitive `MeshType`, and `LevelEditorState`/`LevelEditorPanel`/`LevelEditorBuiltinProvider`, which are UI types)

### Known pre-existing failure, not touched here

`cargo test -p ui_level_editor` (without `--lib`) fails 2 doctests in `level_editor/ui/viewport/components/toggle_button.rs` (`ToggleButton`/`IconName` not in scope in the examples). That file is untouched by this branch and last changed in `8fad8a5d5`.

Closes #557.

https://claude.ai/code/session_013Yn5hMnyckb2t7QsvTLieJ
